### PR TITLE
Fix Unit Test failures in Packaging

### DIFF
--- a/src/Agent.Test/Agent.Test.csproj
+++ b/src/Agent.Test/Agent.Test.csproj
@@ -12,6 +12,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
+    <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
+    <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/Agent.Test/Packaging/PackagerTests.cs
+++ b/src/Agent.Test/Packaging/PackagerTests.cs
@@ -31,6 +31,14 @@ namespace Loupe.Agent.Test.Packaging
             //we have to smack on a GLP or the extension will get replaced.
             m_OutputFileNamePath += "." + Log.PackageExtension;
             File.Delete(m_OutputFileNamePath); //get temp file name creates the file as part of allocating the name.
+
+            Log.EndFile("Rolling over file to be sure we have something to package");
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            File.Delete(m_OutputFileNamePath);
         }
 
 
@@ -67,7 +75,6 @@ namespace Loupe.Agent.Test.Packaging
         {
             using (Packager newPackager = new Packager())
             {
-                File.Delete(m_OutputFileNamePath);
                 newPackager.SendToFile(SessionCriteria.NewSessions, false, m_OutputFileNamePath);
             }
 
@@ -80,12 +87,10 @@ namespace Loupe.Agent.Test.Packaging
         {
             using (Packager newPackager = new Packager())
             {
-                File.Delete(m_OutputFileNamePath);
                 newPackager.SendToFile(SessionCriteria.AllSessions, false, m_OutputFileNamePath);
             }
 
-            Assert.IsTrue(File.Exists(m_OutputFileNamePath));
-            File.Delete(m_OutputFileNamePath);
+            Assert.IsTrue(File.Exists(m_OutputFileNamePath), "There was no output file from the package, most likely because there is no local data to package (like when unit tests are run the first time)");
         }
 
         [Test]
@@ -96,12 +101,10 @@ namespace Loupe.Agent.Test.Packaging
 
             using (Packager newPackager = new Packager())
             {
-                File.Delete(m_OutputFileNamePath);
                 newPackager.SendToFile(SessionCriteria.ActiveSession, false, m_OutputFileNamePath);
             }
 
-            Assert.IsTrue(File.Exists(m_OutputFileNamePath));
-            File.Delete(m_OutputFileNamePath);
+            Assert.IsTrue(File.Exists(m_OutputFileNamePath), "There was no output file from the package, most likely because there is no local data to package (like when unit tests are run the first time)");
         }
 
         [Test]
@@ -109,12 +112,10 @@ namespace Loupe.Agent.Test.Packaging
         {
             using (Packager newPackager = new Packager())
             {
-                File.Delete(m_OutputFileNamePath);
                 newPackager.SendToFile(SessionCriteria.CompletedSessions, false, m_OutputFileNamePath);
             }
 
             //we don't do the assert on this one because there may be no completed sessions package.
-            File.Delete(m_OutputFileNamePath);
         }
 
         [Test]
@@ -122,7 +123,6 @@ namespace Loupe.Agent.Test.Packaging
         {
             using (Packager newPackager = new Packager())
             {
-                File.Delete(m_OutputFileNamePath);
                 newPackager.SendToFile(SessionCriteria.CriticalSessions, false, m_OutputFileNamePath);
             }
 
@@ -135,12 +135,10 @@ namespace Loupe.Agent.Test.Packaging
         {
             using (Packager newPackager = new Packager())
             {
-                File.Delete(m_OutputFileNamePath);
                 newPackager.SendToFile(SessionCriteria.ErrorSessions, false, m_OutputFileNamePath);
             }
 
             //we don't do the assert on this one because there may be no error sessions package.
-            File.Delete(m_OutputFileNamePath);
         }
 
         [Test]
@@ -148,12 +146,10 @@ namespace Loupe.Agent.Test.Packaging
         {
             using (Packager newPackager = new Packager())
             {
-                File.Delete(m_OutputFileNamePath);
                 newPackager.SendToFile(SessionCriteria.WarningSessions, false, m_OutputFileNamePath);
             }
 
             //we don't do the assert on this one because there may be no warning sessions package.
-            File.Delete(m_OutputFileNamePath);
         }
 
         [Test]
@@ -161,12 +157,10 @@ namespace Loupe.Agent.Test.Packaging
         {
             using (Packager newPackager = new Packager())
             {
-                File.Delete(m_OutputFileNamePath);
                 newPackager.SendToFile(SessionCriteria.WarningSessions | SessionCriteria.NewSessions | SessionCriteria.None, false, m_OutputFileNamePath);
             }
 
             //we don't do the assert on this one because there may be no sessions package.
-            File.Delete(m_OutputFileNamePath);
         }
 
         [Test]
@@ -174,12 +168,10 @@ namespace Loupe.Agent.Test.Packaging
         {
             using (Packager newPackager = new Packager())
             {
-                File.Delete(m_OutputFileNamePath);
                 newPackager.SendToFile((s) => s.HostName == Log.SessionSummary.HostName, false, m_OutputFileNamePath);
             }
 
-            Assert.IsTrue(File.Exists(m_OutputFileNamePath));
-            File.Delete(m_OutputFileNamePath);            
+            Assert.IsTrue(File.Exists(m_OutputFileNamePath), "There was no output file from the package, most likely because there is no local data to package (like when unit tests are run the first time)");
         }
 
         [Test]
@@ -188,13 +180,11 @@ namespace Loupe.Agent.Test.Packaging
             using (Packager newPackager = new Packager())
             {
                 m_PredicateMatches = 0;
-                File.Delete(m_OutputFileNamePath);
                 newPackager.SendToFile(OnPackagerNamedMethodPredicate, false, m_OutputFileNamePath);
             }
 
-            Assert.IsTrue(File.Exists(m_OutputFileNamePath));
+            Assert.IsTrue(File.Exists(m_OutputFileNamePath), "There was no output file from the package, most likely because there is no local data to package (like when unit tests are run the first time)");
             Assert.IsTrue(m_PredicateMatches > 0);
-            File.Delete(m_OutputFileNamePath);
         }
 
         private int m_PredicateMatches;
@@ -231,7 +221,6 @@ namespace Loupe.Agent.Test.Packaging
 
                 using (Packager newPackager = new Packager("Loupe", null, loggingPath))
                 {
-                    File.Delete(m_OutputFileNamePath);
                     newPackager.SendToFile(SessionCriteria.AllSessions, false, m_OutputFileNamePath);
                 }
 
@@ -239,7 +228,6 @@ namespace Loupe.Agent.Test.Packaging
             }
             finally
             {
-                File.Delete(m_OutputFileNamePath);
                 Directory.Delete(tempDir, true);
             }
         }
@@ -271,7 +259,7 @@ namespace Loupe.Agent.Test.Packaging
         {
             using (Packager newPackager = new Packager())
             {
-                newPackager.SendToServer(SessionCriteria.AllSessions, false, ServerOverrideServerName, 0, false, ServerOverrideBaseDirectory, null);
+                newPackager.SendToServer(SessionCriteria.AllSessions, false, ServerOverrideServerName, 0, false, null, ServerOverrideRepository);
             }
         }
 

--- a/src/Agent/Agent.csproj
+++ b/src/Agent/Agent.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp1.1;netstandard2.0</TargetFrameworks>
     <PackageId>Loupe.Agent.Core</PackageId>
-    <Version>4.5.0</Version>
+    <Version>4.5.0.1</Version>
     <Company>Gibraltar Software, Inc.</Company>
     <Authors>Gibraltar Software, Inc.</Authors>
     <Product>Loupe</Product>
@@ -16,6 +16,7 @@
     <AssemblyName>Loupe.Agent.NETCore</AssemblyName>
     <RootNamespace>Gibraltar.Agent</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <FileVersion>4.5.0.1</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Core.Test/Core.Test.csproj
+++ b/src/Core.Test/Core.Test.csproj
@@ -10,6 +10,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
+    <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
+    <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/Core.Test/Data/PackagerTests.cs
+++ b/src/Core.Test/Data/PackagerTests.cs
@@ -14,7 +14,7 @@ namespace Loupe.Core.Test.Data
     [TestFixture]
     public class PackagerTests
     {
-        private const string SDSCustomerName = "esymmetrix";
+        private const string RepositoryName = "ConfigurationTest";
 
         private string m_OutputFileNamePath;
         private PackageSendEventArgs m_EndSendResult;
@@ -34,6 +34,15 @@ namespace Loupe.Core.Test.Data
 
             m_OutputFileNamePath = tempFileName + "." + Log.PackageExtension;
             File.Delete(m_OutputFileNamePath); //get temp file name creates the file as part of allocating the name.
+
+            Log.EndFile("Rolling over log file to ensure we have something to package");
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            File.Delete(m_OutputFileNamePath);
+            Assert.IsFalse(File.Exists(m_OutputFileNamePath));
         }
 
         [Test]
@@ -46,7 +55,6 @@ namespace Loupe.Core.Test.Data
 
             //because this is the none package it won't have any content, but won't thrown an error.
             Assert.IsFalse(File.Exists(m_OutputFileNamePath));
-            File.Delete(m_OutputFileNamePath);
         }
 
         [Test]
@@ -64,8 +72,7 @@ namespace Loupe.Core.Test.Data
                 newPackager.SendToFile(SessionCriteria.NewSessions, false, m_OutputFileNamePath, false);
             }
 
-            Assert.IsTrue(File.Exists(m_OutputFileNamePath));
-            File.Delete(m_OutputFileNamePath);
+            Assert.IsTrue(File.Exists(m_OutputFileNamePath), "There was no output file from the package, most likely because there is no local data to package (like when unit tests are run the first time)");
         }
 
         [Test]
@@ -76,8 +83,7 @@ namespace Loupe.Core.Test.Data
                 newPackager.SendToFile(SessionCriteria.AllSessions, false, m_OutputFileNamePath, false);
             }
 
-            Assert.IsTrue(File.Exists(m_OutputFileNamePath));
-            File.Delete(m_OutputFileNamePath);
+            Assert.IsTrue(File.Exists(m_OutputFileNamePath), "There was no output file from the package, most likely because there is no local data to package (like when unit tests are run the first time)");
         }
 
         [Test]
@@ -88,8 +94,7 @@ namespace Loupe.Core.Test.Data
                 newPackager.SendToFile(SessionCriteria.ActiveSession, false, m_OutputFileNamePath, false);
             }
 
-            Assert.IsTrue(File.Exists(m_OutputFileNamePath));
-            File.Delete(m_OutputFileNamePath);
+            Assert.IsTrue(File.Exists(m_OutputFileNamePath), "There was no output file from the package, most likely because there is no local data to package (like when unit tests are run the first time)");
         }
 
         [Test]
@@ -109,7 +114,7 @@ namespace Loupe.Core.Test.Data
                 //create the package
                 newPackager.SendToFile(SessionCriteria.NewSessions, true, m_OutputFileNamePath, false);
             }
-            Assert.IsTrue(File.Exists(m_OutputFileNamePath));
+            Assert.IsTrue(File.Exists(m_OutputFileNamePath), "There was no output file from the package, most likely because there is no local data to package (like when unit tests are run the first time)");
 
             //Now find out what new sessions there are to compare.
             var newSessionsPost = GetNewSessions();
@@ -128,8 +133,6 @@ namespace Loupe.Core.Test.Data
                     Assert.AreEqual(null, newSessionsPost.Find(new Predicate<ISessionSummary>(x => x.Id == newSession.Id)), "The session {0} is still in the index as new and should have been marked sent.", newSession.Id); //null is not found
                 }
             }
-
-            File.Delete(m_OutputFileNamePath);
         }
         
         [Test]
@@ -150,7 +153,7 @@ namespace Loupe.Core.Test.Data
         {
             using (Packager newPackager = new Packager())
             {
-                newPackager.SendToServer(SessionCriteria.AllSessions, false, false, true, true, SDSCustomerName, null, 0, false, null, null, false);
+                newPackager.SendToServer(SessionCriteria.AllSessions, false, false, true, true, RepositoryName, null, 0, false, null, null, false);
             }
         }
 

--- a/src/Core/AsynchronousTask.cs
+++ b/src/Core/AsynchronousTask.cs
@@ -23,7 +23,7 @@ namespace Gibraltar
         /// <param name="state">Arguments to pass to the callBack delegate</param>
         public void Execute(WaitCallback callBack, string title, object state)
         {
-            AsyncTaskArguments arguments = new AsyncTaskArguments(title, state);
+            var arguments = new AsyncTaskArguments(title, state);
             m_ProgressMonitors = arguments.ProgressMonitors;
 
             //and initialize our different UI elements
@@ -86,7 +86,7 @@ namespace Gibraltar
             }
             catch (Exception ex)
             {
-                try //while it seems really unlikely we'll get an exception here, we need to be extra cautious beacuse we're called from the tread pool
+                try //while it seems really unlikely we'll get an exception here, we need to be extra cautious because we're called from the tread pool
                 {
                     //set a result..
                     TaskResults = new AsyncTaskResultEventArgs(AsyncTaskResult.Error, ex.Message, ex);

--- a/src/Core/Data/Packager.cs
+++ b/src/Core/Data/Packager.cs
@@ -514,7 +514,7 @@ namespace Gibraltar.Data
         /// <param name="processAsynchronously">True to return immediately after dispatch, false to wait until completion and then throw an exception if there is an error.</param>
         private void AsyncTaskExecute(WaitCallback asyncTask, string title, object state, bool processAsynchronously)
         {
-            AsynchronousTask execTask = new AsynchronousTask();
+            var execTask = new AsynchronousTask();
             execTask.Execute(asyncTask, title, state);
 
             if (processAsynchronously == false)
@@ -1470,7 +1470,13 @@ namespace Gibraltar.Data
 
         private void SafeHandleAsyncSendException(object state, string message, Exception ex)
         {
-            AsyncTaskArguments asyncTaskArguments = state as AsyncTaskArguments;
+            //unwrap any AggregateExceptions..
+            if (ex is System.AggregateException)
+            {
+                ex = ex.GetBaseException();
+            }
+
+            var asyncTaskArguments = state as AsyncTaskArguments;
             if (asyncTaskArguments != null)
             {
                 asyncTaskArguments.TaskResult = new AsyncTaskResultEventArgs(AsyncTaskResult.Error, message, ex);

--- a/src/Core/Server/Client/Data/DataConverter.cs
+++ b/src/Core/Server/Client/Data/DataConverter.cs
@@ -98,174 +98,181 @@ namespace Gibraltar.Server.Client.Data
         /// <returns></returns>
         public static HubConfigurationXml ByteArrayToHubConfigurationXml(byte[] rawData)
         {
-            HubConfigurationXml configurationXml = new HubConfigurationXml();
+            var configurationXml = new HubConfigurationXml();
 
-            using (MemoryStream documentStream = new MemoryStream(rawData))
+            using (var documentStream = new MemoryStream(rawData))
             {
                 XmlDocument xml = new XmlDocument();
-                xml.Load(documentStream);
-                //            xml.LoadXml(Encoding.UTF8.GetString(rawData));
+                XmlReaderSettings settings = new XmlReaderSettings();
+                settings.DtdProcessing = DtdProcessing.Ignore;
 
-                XmlNode hubConfigurationNode = xml.DocumentElement;
-
-                if (hubConfigurationNode == null)
+                using (var reader = XmlReader.Create(documentStream, settings))
                 {
-                    throw new GibraltarException("There is no server configuration data in the provided raw data");
-                }
+                    xml.Load(reader);
 
-                //read up our attributes
-                XmlAttribute attribute = hubConfigurationNode.Attributes["id"];
-                if (attribute != null)
-                {
-                    configurationXml.id = attribute.InnerText;
-                }
+                    XmlNode hubConfigurationNode = xml.DocumentElement;
 
-                attribute = hubConfigurationNode.Attributes["redirectRequested"];
-                if (attribute != null)
-                {
-                    if (string.IsNullOrEmpty(attribute.InnerText) == false)
+                    if (hubConfigurationNode == null)
                     {
-                        configurationXml.redirectRequested = bool.Parse(attribute.InnerText);
+                        throw new GibraltarException("There is no server configuration data in the provided raw data");
                     }
-                }
 
-                attribute = hubConfigurationNode.Attributes["status"];
-                if (attribute != null)
-                {
-                    if (string.IsNullOrEmpty(attribute.InnerText) == false)
-                    {
-                        configurationXml.status = (HubStatusXml)Enum.Parse(typeof(HubStatusXml), attribute.InnerText, true);
-                    }
-                }
-
-                attribute = hubConfigurationNode.Attributes["timeToLive"];
-                if (attribute != null)
-                {
-                    if (string.IsNullOrEmpty(attribute.InnerText) == false)
-                    {
-                        configurationXml.timeToLive = int.Parse(attribute.InnerText);
-                    }
-                }
-
-                attribute = hubConfigurationNode.Attributes["protocolVersion"];
-                if (attribute != null)
-                {
-                    configurationXml.protocolVersion = attribute.InnerText;
-                }
-
-                //we only read redirect information if we actually got a redirect request.
-                if (configurationXml.redirectRequested)
-                {
-                    attribute = hubConfigurationNode.Attributes["redirectApplicationBaseDirectory"];
+                    //read up our attributes
+                    XmlAttribute attribute = hubConfigurationNode.Attributes["id"];
                     if (attribute != null)
                     {
-                        configurationXml.redirectApplicationBaseDirectory = attribute.InnerText;
+                        configurationXml.id = attribute.InnerText;
                     }
 
-                    attribute = hubConfigurationNode.Attributes["redirectCustomerName"];
+                    attribute = hubConfigurationNode.Attributes["redirectRequested"];
                     if (attribute != null)
                     {
-                        configurationXml.redirectCustomerName = attribute.InnerText;
-                    }
-
-                    attribute = hubConfigurationNode.Attributes["redirectHostName"];
-                    if (attribute != null)
-                    {
-                        configurationXml.redirectHostName = attribute.InnerText;
-                    }
-
-                    attribute = hubConfigurationNode.Attributes["redirectPort"];
-                    if ((attribute != null) && (string.IsNullOrEmpty(attribute.InnerText) == false))
-                    {
-                        configurationXml.redirectPort = int.Parse(attribute.InnerText);
-                        configurationXml.redirectPortSpecified = true;
-                    }
-
-                    attribute = hubConfigurationNode.Attributes["redirectUseGibraltarSds"];
-                    if ((attribute != null) && (string.IsNullOrEmpty(attribute.InnerText) == false))
-                    {
-                        configurationXml.redirectUseGibraltarSds = bool.Parse(attribute.InnerText);
-                        configurationXml.redirectUseGibraltarSdsSpecified = true;
-                    }
-
-                    attribute = hubConfigurationNode.Attributes["redirectUseSsl"];
-                    if ((attribute != null) && (string.IsNullOrEmpty(attribute.InnerText) == false))
-                    {
-                        configurationXml.redirectUseSsl = bool.Parse(attribute.InnerText);
-                        configurationXml.redirectUseSslSpecified = true;
-                    }
-                }
-
-                //now move on to the child elements..  I'm avoiding XPath to avoid failure due to XML schema variations
-                if (hubConfigurationNode.HasChildNodes)
-                {
-                    XmlNode expirationDtNode = null;
-                    XmlNode publicKeyNode = null;
-                    XmlNode liveStreamNode = null;
-                    foreach (XmlNode curChildNode in hubConfigurationNode.ChildNodes)
-                    {
-                        if (curChildNode.NodeType == XmlNodeType.Element)
+                        if (string.IsNullOrEmpty(attribute.InnerText) == false)
                         {
-                            switch (curChildNode.Name)
+                            configurationXml.redirectRequested = bool.Parse(attribute.InnerText);
+                        }
+                    }
+
+                    attribute = hubConfigurationNode.Attributes["status"];
+                    if (attribute != null)
+                    {
+                        if (string.IsNullOrEmpty(attribute.InnerText) == false)
+                        {
+                            configurationXml.status =
+                                (HubStatusXml) Enum.Parse(typeof(HubStatusXml), attribute.InnerText, true);
+                        }
+                    }
+
+                    attribute = hubConfigurationNode.Attributes["timeToLive"];
+                    if (attribute != null)
+                    {
+                        if (string.IsNullOrEmpty(attribute.InnerText) == false)
+                        {
+                            configurationXml.timeToLive = int.Parse(attribute.InnerText);
+                        }
+                    }
+
+                    attribute = hubConfigurationNode.Attributes["protocolVersion"];
+                    if (attribute != null)
+                    {
+                        configurationXml.protocolVersion = attribute.InnerText;
+                    }
+
+                    //we only read redirect information if we actually got a redirect request.
+                    if (configurationXml.redirectRequested)
+                    {
+                        attribute = hubConfigurationNode.Attributes["redirectApplicationBaseDirectory"];
+                        if (attribute != null)
+                        {
+                            configurationXml.redirectApplicationBaseDirectory = attribute.InnerText;
+                        }
+
+                        attribute = hubConfigurationNode.Attributes["redirectCustomerName"];
+                        if (attribute != null)
+                        {
+                            configurationXml.redirectCustomerName = attribute.InnerText;
+                        }
+
+                        attribute = hubConfigurationNode.Attributes["redirectHostName"];
+                        if (attribute != null)
+                        {
+                            configurationXml.redirectHostName = attribute.InnerText;
+                        }
+
+                        attribute = hubConfigurationNode.Attributes["redirectPort"];
+                        if ((attribute != null) && (string.IsNullOrEmpty(attribute.InnerText) == false))
+                        {
+                            configurationXml.redirectPort = int.Parse(attribute.InnerText);
+                            configurationXml.redirectPortSpecified = true;
+                        }
+
+                        attribute = hubConfigurationNode.Attributes["redirectUseGibraltarSds"];
+                        if ((attribute != null) && (string.IsNullOrEmpty(attribute.InnerText) == false))
+                        {
+                            configurationXml.redirectUseGibraltarSds = bool.Parse(attribute.InnerText);
+                            configurationXml.redirectUseGibraltarSdsSpecified = true;
+                        }
+
+                        attribute = hubConfigurationNode.Attributes["redirectUseSsl"];
+                        if ((attribute != null) && (string.IsNullOrEmpty(attribute.InnerText) == false))
+                        {
+                            configurationXml.redirectUseSsl = bool.Parse(attribute.InnerText);
+                            configurationXml.redirectUseSslSpecified = true;
+                        }
+                    }
+
+                    //now move on to the child elements..  I'm avoiding XPath to avoid failure due to XML schema variations
+                    if (hubConfigurationNode.HasChildNodes)
+                    {
+                        XmlNode expirationDtNode = null;
+                        XmlNode publicKeyNode = null;
+                        XmlNode liveStreamNode = null;
+                        foreach (XmlNode curChildNode in hubConfigurationNode.ChildNodes)
+                        {
+                            if (curChildNode.NodeType == XmlNodeType.Element)
                             {
-                                case "expirationDt":
-                                    expirationDtNode = curChildNode;
-                                    break;
-                                case "publicKey":
-                                    publicKeyNode = curChildNode;
-                                    break;
-                                case "liveStream":
-                                    liveStreamNode = curChildNode;
-                                    break;
-                                default:
+                                switch (curChildNode.Name)
+                                {
+                                    case "expirationDt":
+                                        expirationDtNode = curChildNode;
+                                        break;
+                                    case "publicKey":
+                                        publicKeyNode = curChildNode;
+                                        break;
+                                    case "liveStream":
+                                        liveStreamNode = curChildNode;
+                                        break;
+                                    default:
+                                        break;
+                                }
+
+                                if ((expirationDtNode != null) && (publicKeyNode != null) && (liveStreamNode != null))
                                     break;
                             }
-
-                            if ((expirationDtNode != null) && (publicKeyNode != null) && (liveStreamNode != null))
-                                break;
                         }
-                    }
 
-                    if (expirationDtNode != null)
-                    {
-                        attribute = expirationDtNode.Attributes["DateTime"];
-                        string dateTimeRaw = attribute.InnerText;
-
-                        attribute = expirationDtNode.Attributes["Offset"];
-                        string timeZoneOffset = attribute.InnerText;
-
-                        if ((string.IsNullOrEmpty(dateTimeRaw) == false) && (string.IsNullOrEmpty(timeZoneOffset) == false))
+                        if (expirationDtNode != null)
                         {
-                            configurationXml.expirationDt = new DateTimeOffsetXml();
-                            configurationXml.expirationDt.DateTime = DateTime.Parse(dateTimeRaw);
-                            configurationXml.expirationDt.Offset = int.Parse(timeZoneOffset);
+                            attribute = expirationDtNode.Attributes["DateTime"];
+                            string dateTimeRaw = attribute.InnerText;
+
+                            attribute = expirationDtNode.Attributes["Offset"];
+                            string timeZoneOffset = attribute.InnerText;
+
+                            if ((string.IsNullOrEmpty(dateTimeRaw) == false) &&
+                                (string.IsNullOrEmpty(timeZoneOffset) == false))
+                            {
+                                configurationXml.expirationDt = new DateTimeOffsetXml();
+                                configurationXml.expirationDt.DateTime = DateTime.Parse(dateTimeRaw);
+                                configurationXml.expirationDt.Offset = int.Parse(timeZoneOffset);
+                            }
                         }
-                    }
 
-                    if (publicKeyNode != null)
-                    {
-                        configurationXml.publicKey = publicKeyNode.InnerText;
-                    }
-
-                    if (liveStreamNode != null)
-                    {
-                        attribute = liveStreamNode.Attributes["agentPort"];
-                        string agentPortRaw = attribute.InnerText;
-
-                        attribute = liveStreamNode.Attributes["clientPort"];
-                        string clientPortRaw = attribute.InnerText;
-
-                        attribute = liveStreamNode.Attributes["useSsl"];
-                        string useSslRaw = attribute.InnerText;
-
-                        if ((string.IsNullOrEmpty(agentPortRaw) == false)
-                            && (string.IsNullOrEmpty(clientPortRaw) == false)
-                            && (string.IsNullOrEmpty(useSslRaw) == false))
+                        if (publicKeyNode != null)
                         {
-                            configurationXml.liveStream = new LiveStreamServerXml();
-                            configurationXml.liveStream.agentPort = int.Parse(agentPortRaw);
-                            configurationXml.liveStream.clientPort = int.Parse(clientPortRaw);
-                            configurationXml.liveStream.useSsl = bool.Parse(useSslRaw);
+                            configurationXml.publicKey = publicKeyNode.InnerText;
+                        }
+
+                        if (liveStreamNode != null)
+                        {
+                            attribute = liveStreamNode.Attributes["agentPort"];
+                            string agentPortRaw = attribute.InnerText;
+
+                            attribute = liveStreamNode.Attributes["clientPort"];
+                            string clientPortRaw = attribute.InnerText;
+
+                            attribute = liveStreamNode.Attributes["useSsl"];
+                            string useSslRaw = attribute.InnerText;
+
+                            if ((string.IsNullOrEmpty(agentPortRaw) == false)
+                                && (string.IsNullOrEmpty(clientPortRaw) == false)
+                                && (string.IsNullOrEmpty(useSslRaw) == false))
+                            {
+                                configurationXml.liveStream = new LiveStreamServerXml();
+                                configurationXml.liveStream.agentPort = int.Parse(agentPortRaw);
+                                configurationXml.liveStream.clientPort = int.Parse(clientPortRaw);
+                                configurationXml.liveStream.useSsl = bool.Parse(useSslRaw);
+                            }
                         }
                     }
                 }

--- a/src/Core/Server/Client/HubConnection.cs
+++ b/src/Core/Server/Client/HubConnection.cs
@@ -699,8 +699,9 @@ namespace Gibraltar.Server.Client
                 var configurationGetRequest = new HubConfigurationGetRequest();
                 await channel.ExecuteRequest(configurationGetRequest, 1).ConfigureAwait(false); //we'd like it to succeed, so we'll give it one retry 
 
+                var configurationXml = configurationGetRequest.Configuration;
+
                 //now, if we got back a redirect we need to go THERE to get the status.
-                HubConfigurationXml configurationXml = configurationGetRequest.Configuration;
                 if (configurationXml.redirectRequested)
                 {
                     //recursively try again.


### PR DESCRIPTION
Most packaging unit tests are failing for a range of reasons.  This fixes them by correcting exceptions where the wrong exception is thrown, adjusting a few tests that are no longer correct, and fixed a few legitimate defects in our implementations, that now I'm worried are real problems in production.