### PR TITLE
Add ProviderAlias to LoupeLoggerProvider for configuration compatibility

### DIFF
--- a/src/Extensions.Logging/Extensions.Logging.csproj
+++ b/src/Extensions.Logging/Extensions.Logging.csproj
@@ -19,12 +19,16 @@
     <AssemblyVersion>4.5.1.0</AssemblyVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU' And '$(TargetFramework)' == 'netcoreapp1.1'">
-    <DefineConstants>TRACE;DEBUG;NETCOREAPP1_1</DefineConstants>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU' And '$(TargetFramework)' == 'netcoreapp1.1'">
-    <DocumentationFile>bin\Release\netcoreapp1.1\Loupe.Extensions.Logging.xml</DocumentationFile>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp1.1'">
+    <DefineConstants>NETCOREAPP1_1</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DocumentationFile>bin\Release\$(TargetFramework)\Loupe.Extensions.Logging.xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/src/Extensions.Logging/LoggerBuilderExtensions.cs
+++ b/src/Extensions.Logging/LoggerBuilderExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-
 #if(NETCOREAPP2_0 || NETSTANDARD2_0)
 namespace Loupe.Extensions.Logging
 {

--- a/src/Extensions.Logging/LoupeLogger.cs
+++ b/src/Extensions.Logging/LoupeLogger.cs
@@ -49,7 +49,7 @@ namespace Loupe.Extensions.Logging
                         throw new ArgumentOutOfRangeException(nameof(logLevel), logLevel, null);
                 }
 
-            Gibraltar.Agent.Log.Write(severity, "loupe", 1, exception, LogWriteMode.Queued, null, _category, null, formatter(state, exception), state);
+            Gibraltar.Agent.Log.Write(severity, "Microsoft.Extensions.Logging", 1, exception, LogWriteMode.Queued, null, _category, null, formatter(state, exception), state);
         }
 
         /// <inheritdoc />

--- a/src/Extensions.Logging/LoupeLoggerProvider.cs
+++ b/src/Extensions.Logging/LoupeLoggerProvider.cs
@@ -1,14 +1,15 @@
-﻿using System.Threading;
-using Gibraltar.Agent;
+﻿using Gibraltar.Agent;
 using Loupe.Configuration;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Loupe.Extensions.Logging
 {
+    #if(NETCOREAPP2_0 || NETSTANDARD2_0)
+    [ProviderAlias("Loupe")]
+    #endif
     public class LoupeLoggerProvider : ILoggerProvider
     {
-//        private readonly AgentConfiguration _agentConfiguration;
         public LoupeLoggerProvider(IConfiguration configuration)
         {
             var agentConfiguration = new AgentConfiguration();


### PR DESCRIPTION
Adding this, for .NET Core 2.0 and later, means that users can add level filters in the top-level `Logging` section of config under a `Loupe` property, e.g.

```json
{
  "Logging": {
    "LogLevel": {
      "Default": "Debug"
    },
    "Loupe": {
      "LogLevel": {
        "Default": "Information",
        "System": "Warning",
        "Microsoft": "Warning",
      }
    }
  }
}
```