### PR TITLE
Issue #26 - Correct file system locking on UNIX to fix maintenance & send actions

### DIFF
--- a/src/Agent.Test/LogMessages/ApplicationUserTests.cs
+++ b/src/Agent.Test/LogMessages/ApplicationUserTests.cs
@@ -57,7 +57,7 @@ namespace Loupe.Agent.Test.LogMessages
                 Log.Write(LogMessageSeverity.Information, "Loupe", null, "ApplicationUserAssignJustOnce", null,
                     LogWriteMode.WaitForCommit, null, "LogTests.ApplicationUser.Assign Just Once", "This message should be attributed to ApplicationUserAssignJustOnce",
                     "And we should NOT get the resolution event following it.");
-                Assert.AreEqual(1, m_UserResolutionRequests, "We didn't get exactly one resolution after the second message");
+                Assert.AreEqual(1, m_UserResolutionRequests, "We got an additional ResolveApplicationUser event after our initial attempt.");
             }
             finally
             {

--- a/src/Agent.Test/LogMessages/LogTests.cs
+++ b/src/Agent.Test/LogMessages/LogTests.cs
@@ -80,11 +80,11 @@ namespace Loupe.Agent.Test.LogMessages
         public void WriteException()
         {
             Log.Warning(new AssertionException("This is our test assertion exception"),
-                        "Test.Agent.LogMessages.Write", "Test of logging exception attachement.", null);
+                        "Test.Agent.LogMessages.Write", "Test of logging exception attachment.", null);
 
             Log.Warning(new AssertionException("This is our top exception", new AssertionException("This is our middle exception",
                                                new AssertionException("This is our bottom exception"))),
-                      "Test.Agent.LogMessages.Write", "Test of logging exception attachement with nested exceptions.", null);
+                      "Test.Agent.LogMessages.Write", "Test of logging exception attachment with nested exceptions.", null);
         }
 
         /// <summary>

--- a/src/Agent/Agent.csproj
+++ b/src/Agent/Agent.csproj
@@ -3,11 +3,11 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp1.1;netstandard2.0</TargetFrameworks>
     <PackageId>Loupe.Agent.Core</PackageId>
-    <Version>4.6.1.0</Version>
+    <Version>4.7.0.0</Version>
     <Company>Gibraltar Software, Inc.</Company>
     <Authors>Gibraltar Software, Inc.</Authors>
     <Product>Loupe</Product>
-    <Copyright>Copyright © 2008-2018 Gibraltar Software, Inc.</Copyright>
+    <Copyright>Copyright © 2008-2019 Gibraltar Software, Inc.</Copyright>
     <Description>The Loupe Agent for .NET Core - a black box for recording diagnostic information for your .NET Core application.  Download additional agent extensions for extended integration with different .NET Core subsystems and third party libraries.</Description>
     <PackageProjectUrl>https://onloupe.com</PackageProjectUrl>
     <PackageIconUrl>https://onloupe.com/assets/icons/favicon.ico</PackageIconUrl>
@@ -16,7 +16,7 @@
     <AssemblyName>Loupe.Agent.NETCore</AssemblyName>
     <RootNamespace>Gibraltar.Agent</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <FileVersion>4.6.1.0</FileVersion>
+    <FileVersion>4.7.0.0</FileVersion>
     <AssemblyVersion>4.5.1.0</AssemblyVersion>
     <DisableImplicitAssetTargetFallback>true</DisableImplicitAssetTargetFallback>
   </PropertyGroup>

--- a/src/AspNetCore2/AspNetCore2.csproj
+++ b/src/AspNetCore2/AspNetCore2.csproj
@@ -5,11 +5,11 @@
     <AssemblyName>Loupe.Agent.AspNetCore</AssemblyName>
     <RootNamespace>Loupe.Agent.AspNetCore</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>4.6.1.0</Version>
+    <Version>4.7.0.0</Version>
     <Authors>Gibraltar Software, Inc.</Authors>
     <Company>Gibraltar Software, Inc.</Company>
     <Product>Loupe</Product>
-    <Copyright>Copyright © 2008-2018 Gibraltar Software, Inc.</Copyright>
+    <Copyright>Copyright © 2008-2019 Gibraltar Software, Inc.</Copyright>
     <PackageProjectUrl>https://onloupe.com</PackageProjectUrl>
     <PackageIconUrl>https://onloupe.com/assets/icons/favicon.ico</PackageIconUrl>
     <RepositoryUrl>https://github.com/gibraltarsoftware/loupe.agent.core</RepositoryUrl>

--- a/src/Core.Test/StringReferenceTests.cs
+++ b/src/Core.Test/StringReferenceTests.cs
@@ -34,6 +34,8 @@ namespace Loupe.Core.Test
             Assert.AreEqual(1, testCollection.Count);
             primeZero = null;
             GC.Collect(); // And make sure GC kills it.
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
             Assert.AreEqual(0, testCollection.Pack()); // Confirm that it's gone.
             primeZero = GetTestString(0);
             Assert.AreEqual(1, testCollection.PackAndOrAdd(ref primeZero)); // Add it back.
@@ -45,10 +47,14 @@ namespace Loupe.Core.Test
 
             primeZero = null; // Remove the original reference.
             GC.Collect(); // And make sure GC kills it (but won't kill the new copy).
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
             Assert.AreEqual(1, testCollection.Pack());
 
             testZero = null; // Remove the new reference.
             GC.Collect(); // And make sure GC kills it.
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
             Assert.AreEqual(1, testCollection.PackAndOrAdd(ref primeOne));
 
             primeZero = GetTestString(0);
@@ -60,6 +66,8 @@ namespace Loupe.Core.Test
 
             primeOne = null; // Remove the original reference.
             GC.Collect(); // And make sure GC kills it.
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
             Assert.AreEqual(2, testCollection.PackAndOrAdd(ref primeTwo));
             primeOne = GetTestString(1);
             Assert.AreEqual(3, testCollection.PackAndOrAdd(ref primeOne));
@@ -74,6 +82,8 @@ namespace Loupe.Core.Test
             primeOne = null; // Remove the only reference.
             primeTwo = null; // Remove the only reference.
             GC.Collect(); // And make sure GC kills them.
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
             Assert.AreEqual(2, testCollection.Pack());
 
             primeZero = GetTestString(0);

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -4,8 +4,8 @@
     <TargetFrameworks>netcoreapp1.1;netstandard2.0</TargetFrameworks>
     <AssemblyName>Loupe.Core.NETCore</AssemblyName>
     <RootNamespace>Gibraltar</RootNamespace>
-    <Version>4.6.1.0</Version>
-    <Copyright>Copyright © 2008-2018 Gibraltar Software, Inc.</Copyright>
+    <Version>4.7.0.0</Version>
+    <Copyright>Copyright © 2008-2019 Gibraltar Software, Inc.</Copyright>
     <Description>Internal functionality for the Loupe Agent for .NET Core.  Add Loupe.Agent.Core to your project to use Loupe.</Description>
     <Product>Loupe</Product>
     <Company>Gibraltar Software, Inc.</Company>

--- a/src/Core/Data/FileHeader.cs
+++ b/src/Core/Data/FileHeader.cs
@@ -139,8 +139,9 @@ namespace Gibraltar.Data
             }
 
             //we should have exactly filled our header to size.
+#if DEBUG
             Debug.Assert(curByteIndex == HeaderSize);
-
+#endif
             return rawData;
         }
 

--- a/src/Core/Data/Internal/RepositoryMaintenance.cs
+++ b/src/Core/Data/Internal/RepositoryMaintenance.cs
@@ -526,7 +526,7 @@ namespace Gibraltar.Data.Internal
             try
             {
                 FileStream sourceFile = null;
-                using (sourceFile = FileHelper.OpenFileStream(sessionFileNamePath, FileMode.Open, FileAccess.ReadWrite, FileShare.Read))
+                using (sourceFile = FileHelper.OpenFileStream(sessionFileNamePath, FileMode.Open, FileAccess.Read, FileShare.Read))
                 {
                     if (sourceFile == null)
                     {

--- a/src/Core/Data/Internal/RepositoryPublishClient.cs
+++ b/src/Core/Data/Internal/RepositoryPublishClient.cs
@@ -484,9 +484,11 @@ namespace Gibraltar.Data.Internal
         {
             var sessionId = new Guid(sessionSummary.id);
 
+#if DEBUG
             Debug.Assert(!String.IsNullOrEmpty(sessionSummary.sessionDetail.productName));
             Debug.Assert(!String.IsNullOrEmpty(sessionSummary.sessionDetail.applicationName));
             Debug.Assert(!String.IsNullOrEmpty(sessionSummary.sessionDetail.applicationVersion));
+#endif
 
             //we consider a session complete (since we're the source repository) with just the header if there
             //is no session file.

--- a/src/Core/Data/Internal/TransportPackageBase.cs
+++ b/src/Core/Data/Internal/TransportPackageBase.cs
@@ -113,7 +113,9 @@ namespace Gibraltar.Data.Internal
         public void Send(ProgressMonitorStack progressMonitors)
         {
             Status = OnSend(progressMonitors);
+#if DEBUG
             Debug.Assert(Status != null);
+#endif
         }
 
 

--- a/src/Core/Data/PathManager.cs
+++ b/src/Core/Data/PathManager.cs
@@ -187,12 +187,28 @@ namespace Gibraltar.Data
 
         private static string GetLocalApplicationDataPath()
         {
-            return Environment.GetEnvironmentVariable(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "LocalAppData" : "Home");
+#if (NETCOREAPP1_1)
+            return Environment.GetEnvironmentVariable(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "LocalAppData" : "HOME");
+#else
+            var path = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            if (string.IsNullOrWhiteSpace(path))
+                path = Environment.GetEnvironmentVariable("HOME");
+
+            return path;
+#endif
         }
 
         private static string GetCommonApplicationDataPath()
         {
-            return Environment.GetEnvironmentVariable(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "ProgramData" : "Home");
+#if (NETCOREAPP1_1)
+            return Environment.GetEnvironmentVariable(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "ProgramData" : "HOME");
+#else
+            var path = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+            if (string.IsNullOrWhiteSpace(path))
+                path = Environment.GetEnvironmentVariable("HOME");
+
+            return path;
+#endif
         }
     }
 }

--- a/src/Core/Messaging/FileMessenger.cs
+++ b/src/Core/Messaging/FileMessenger.cs
@@ -411,7 +411,7 @@ namespace Gibraltar.Messaging
 
             //we now have a unique file name, create the file.
             FileSystemTools.EnsurePathExists(fileNamePath);
-            m_CurrentFile = new FileStream(fileNamePath, FileMode.CreateNew, FileAccess.Write);
+            m_CurrentFile = new FileStream(fileNamePath, FileMode.CreateNew, FileAccess.Write, FileShare.None);
 
             //and open a serializer on it
             m_CurrentSerializer = new GLFWriter(m_CurrentFile, Publisher.SessionSummary, m_CurrentSessionFile, DateTimeOffset.Now);
@@ -438,6 +438,6 @@ namespace Gibraltar.Messaging
             return FileSystemTools.SanitizeFileName(fileName);
         }
 
-        #endregion
+#endregion
     }
 }

--- a/src/Core/Messaging/Publisher.cs
+++ b/src/Core/Messaging/Publisher.cs
@@ -538,8 +538,9 @@ namespace Gibraltar.Messaging
 
         private void StampPacket(IMessengerPacket packet, DateTimeOffset defaultTimeStamp)
         {
+#if DEBUG
             Debug.Assert(defaultTimeStamp.Ticks > 0);
-            
+#endif            
             //we don't check dependencies on command packets, it'll fail (and they aren't written out)
             if ((packet is CommandPacket) == false)
             {

--- a/src/Core/Monitor/EventMetricSample.cs
+++ b/src/Core/Monitor/EventMetricSample.cs
@@ -256,8 +256,9 @@ namespace Gibraltar.Monitor
                         //We have a default value so we're going to return what it has - either null or a numerical value
                         int valueIndex = Metric.Definition.Values.IndexOf(defaultValueDefinition);
 
+#if DEBUG
                         Debug.Assert(valueIndex >= 0);  //it has to be because we got the object above, so I'm only doing an assert 
-
+#endif
                         //all trendable values are castable
                         if (Values[valueIndex] == null)
                         {

--- a/src/Core/Monitor/Internal/GibraltarCachedPacket.cs
+++ b/src/Core/Monitor/Internal/GibraltarCachedPacket.cs
@@ -123,8 +123,8 @@ namespace Gibraltar.Monitor.Internal
 #if DEBUG
             if (m_TimeStamp == DateTimeOffset.MinValue && Debugger.IsAttached)
                 Debugger.Break(); // Stop the debugger before the Assert
-#endif
             Debug.Assert(m_TimeStamp.Year > 1 ); //watch for timestamp being some variation of zero
+#endif
 
             packet.SetField("Sequence", m_Sequence);
             packet.SetField("TimeStamp", m_TimeStamp);

--- a/src/Core/Monitor/Internal/LogMessagePacket.cs
+++ b/src/Core/Monitor/Internal/LogMessagePacket.cs
@@ -344,7 +344,9 @@ namespace Gibraltar.Monitor.Internal
             //now we want to sort by our nice increasing sequence #
             int compareResult = Sequence.CompareTo(other.Sequence);
 
+#if DEBUG
             Debug.Assert(compareResult != 0); //no way we should ever get an equal at this point.
+#endif
 
             return compareResult;
         }
@@ -514,10 +516,11 @@ namespace Gibraltar.Monitor.Internal
 
         void IPacket.WriteFields(PacketDefinition definition, SerializedPacket packet)
         {
-
             // We depend on the ThreadInfoPacket!
+#if DEBUG
             Debug.Assert(ThreadInfoPacket != null);
             Debug.Assert(ThreadInfoPacket.ThreadId == ThreadId);
+#endif
 
             packet.SetField("ID", m_ID);
             packet.SetField("Caption", m_Caption);

--- a/src/Core/Monitor/Internal/MetricPacket.cs
+++ b/src/Core/Monitor/Internal/MetricPacket.cs
@@ -279,7 +279,9 @@ namespace Gibraltar.Monitor.Internal
         IPacket[] IPacket.GetRequiredPackets()
         {
             //a metric depends on its metric definition
+#if DEBUG
             Debug.Assert(m_MetricDefinitionPacket != null);
+#endif
             return new IPacket[] {m_MetricDefinitionPacket};
         }
 

--- a/src/Core/Monitor/Internal/MetricSamplePacket.cs
+++ b/src/Core/Monitor/Internal/MetricSamplePacket.cs
@@ -129,7 +129,9 @@ namespace Gibraltar.Monitor.Internal
             //now we want to sort by our nice increasing sequence #
             int compareResult = Sequence.CompareTo(other.Sequence);
 
+#if DEBUG
             Debug.Assert(compareResult != 0); //no way we should ever get an equal at this point.
+#endif
 
             return compareResult;
         }
@@ -228,7 +230,9 @@ namespace Gibraltar.Monitor.Internal
         IPacket[] IPacket.GetRequiredPackets()
         {
             //we depend on our metric
+#if DEBUG
             Debug.Assert(m_MetricPacket != null);
+#endif
             return new IPacket[] {m_MetricPacket};
         }
 

--- a/src/Core/Monitor/Internal/SessionClosePacket.cs
+++ b/src/Core/Monitor/Internal/SessionClosePacket.cs
@@ -60,8 +60,9 @@ namespace Gibraltar.Monitor.Internal
             //now we want to sort by our nice increasing sequence #
             int compareResult = Sequence.CompareTo(other.Sequence);
 
+#if DEBUG
             Debug.Assert(compareResult != 0); //no way we should ever get an equal at this point.
-
+#endif
             return compareResult;
         }
 

--- a/src/Core/Monitor/LocalRepository.cs
+++ b/src/Core/Monitor/LocalRepository.cs
@@ -1147,8 +1147,7 @@ namespace Gibraltar.Monitor
 
                         try
                         {
-                            //sourceFile = new FileStream(fileFragment, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
-                            sourceFile = FileHelper.OpenFileStream(fileFragment.FullName, FileMode.Open, FileAccess.ReadWrite, FileShare.Read);
+                            sourceFile = FileHelper.OpenFileStream(fileFragment.FullName, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
                             if (sourceFile == null)
                             {
                                 if (m_LoggingEnabled) Log.Write(LogMessageSeverity.Warning, LogCategory, "Unable to Mark Session as Crashed", "Unable to completely convert session {0} from being marked as running to crashed in repository at '{1}' because the fragment '{2}' could not be opened",

--- a/src/Core/Monitor/SessionFileInfo.cs
+++ b/src/Core/Monitor/SessionFileInfo.cs
@@ -22,9 +22,10 @@ namespace Gibraltar.Monitor
         /// </summary>
         public SessionFileInfo(SessionHeader sessionHeader, T fileInfo, bool isNew)
         {
+#if DEBUG
             Debug.Assert(sessionHeader != null);
             Debug.Assert(fileInfo != null);
-
+#endif
             m_SessionId = sessionHeader.Id;
 
             //this will be our best session header since it's the first

--- a/src/Core/ProgressMonitor.cs
+++ b/src/Core/ProgressMonitor.cs
@@ -109,7 +109,9 @@ namespace Gibraltar
                 {
                     m_CompletedSteps = value;
 
+#if DEBUG
                     Debug.Assert(m_CompletedSteps <= m_MaxSteps);
+#endif
 
                     //and invalidate the cached percentage
                     m_PercentCompleteValid = false;

--- a/src/Core/Server/Client/SessionHeaderUploadRequest.cs
+++ b/src/Core/Server/Client/SessionHeaderUploadRequest.cs
@@ -41,8 +41,10 @@ namespace Gibraltar.Server.Client
         {
             string strRequestUrl = string.Format("/Hub/Hosts/{0}/Sessions/{1}/session.xml", ClientId, SessionHeader.id);
 
+#if DEBUG
             Debug.Assert(SessionHeader.sessionDetail.status != SessionStatusXml.running);
             Debug.Assert(SessionHeader.sessionDetail.status != SessionStatusXml.unknown);
+#endif
 
             //we can't encode using XmlSerializer because it will only work with public types, and we 
             //aren't public if we get ILMerged into something.

--- a/src/Core/StringReference.cs
+++ b/src/Core/StringReference.cs
@@ -339,7 +339,9 @@ namespace Gibraltar
                     if (m_ExtraCount <= 0 && (adding == false || nextPackIndex < 0))
                     {
                         // There's no array and we don't need to add one to the extras, so let's do this quick and exit.
+#if DEBUG
                         Debug.Assert(m_ExtraStrings == null); // Should always be the case if we clear it correctly down below.
+#endif
                         if (adding) // Are we adding or only packing?
                         {
                             m_FirstString = new WeakReference(newString);

--- a/src/EFCore2/EFCore2.csproj
+++ b/src/EFCore2/EFCore2.csproj
@@ -4,10 +4,10 @@
     <LangVersion>latest</LangVersion>
     <AssemblyName>Loupe.Agent.EntityFrameworkCore</AssemblyName>
     <RootNamespace>Loupe.Agent.EntityFrameworkCore</RootNamespace>
-    <Version>4.6.1.0</Version>
+    <Version>4.7.0.0</Version>
     <Authors>Gibraltar Software, Inc.</Authors>
     <Product>Loupe</Product>
-    <Copyright>Copyright © 2008-2018 Gibraltar Software, Inc.</Copyright>
+    <Copyright>Copyright © 2008-2019 Gibraltar Software, Inc.</Copyright>
     <PackageProjectUrl>https://onloupe.com</PackageProjectUrl>
     <PackageIconUrl>https://onloupe.com/assets/icons/favicon.ico</PackageIconUrl>
     <RepositoryUrl>https://github.com/gibraltarsoftware/loupe.agent.core</RepositoryUrl>

--- a/src/Extensibility/Extensibility.csproj
+++ b/src/Extensibility/Extensibility.csproj
@@ -3,11 +3,11 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.6</TargetFramework>
     <PackageId>Loupe.Agent.Core.Extensibility</PackageId>
-    <Version>4.6.1.0</Version>
+    <Version>4.7.0.0</Version>
     <Authors>Gibraltar Software, Inc.</Authors>
     <Product>Loupe</Product>
     <Description>Shared types for the Loupe Agent for .NET Core.  Add Loupe.Agent.Core to your project to use Loupe.</Description>
-    <Copyright>Copyright © 2008-2018 Gibraltar Software, Inc.</Copyright>
+    <Copyright>Copyright © 2008-2019 Gibraltar Software, Inc.</Copyright>
     <Company>Gibraltar Software, Inc.</Company>
     <AssemblyName>Loupe.Extensibility.NETCore</AssemblyName>
     <RootNamespace>Loupe</RootNamespace>

--- a/src/Extensions.Logging/Extensions.Logging.csproj
+++ b/src/Extensions.Logging/Extensions.Logging.csproj
@@ -5,17 +5,17 @@
     <AssemblyName>Loupe.Extensions.Logging</AssemblyName>
     <RootNamespace>Loupe.Extensions.Logging</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>4.6.1.0</Version>
+    <Version>4.7.0.0</Version>
     <Authors>Gibraltar Software, Inc.</Authors>
     <Company>Gibraltar Software, Inc.</Company>
     <Product>Loupe</Product>
     <Description>Implements Microsoft.Extensions.Logging.Abstractions for the Loupe Agent for .NET Core (Loupe.Agent.Core)</Description>
-    <Copyright>Copyright © 2008-2018 Gibraltar Software, Inc.</Copyright>
+    <Copyright>Copyright © 2008-2019 Gibraltar Software, Inc.</Copyright>
     <PackageProjectUrl>https://onloupe.com</PackageProjectUrl>
     <PackageIconUrl>https://onloupe.com/assets/icons/favicon.ico</PackageIconUrl>
     <RepositoryUrl>https://github.com/gibraltarsoftware/loupe.agent.core</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <FileVersion>4.6.1.0</FileVersion>
+    <FileVersion>4.7.0.0</FileVersion>
     <AssemblyVersion>4.5.1.0</AssemblyVersion>
     <DisableImplicitAssetTargetFallback>true</DisableImplicitAssetTargetFallback>
   </PropertyGroup>

--- a/src/Services/Services.csproj
+++ b/src/Services/Services.csproj
@@ -4,11 +4,11 @@
     <LangVersion>latest</LangVersion>
     <AssemblyName>Loupe.Agent.Core.Services</AssemblyName>
     <RootNamespace>Loupe.Agent.Core.Services</RootNamespace>
-    <Version>4.6.1.0</Version>
+    <Version>4.7.0.0</Version>
     <Company>Gibraltar Software, Inc.</Company>
     <Authors>Gibraltar Software, Inc.</Authors>
     <Product>Loupe</Product>
-    <Copyright>Copyright © 2008-2018 Gibraltar Software, Inc.</Copyright>
+    <Copyright>Copyright © 2008-2019 Gibraltar Software, Inc.</Copyright>
     <PackageProjectUrl>https://onloupe.com</PackageProjectUrl>
     <PackageIconUrl>https://onloupe.com/assets/icons/favicon.ico</PackageIconUrl>
     <RepositoryUrl>https://github.com/gibraltarsoftware/loupe.agent.core</RepositoryUrl>


### PR DESCRIPTION
The code was insufficiently strict with file sharing options and this caused incorrect behavior for file maintenance and send (with open files being considered eligible for conversion and send to server)