### PR TITLE
Resolve #47 - IPrincipal is ignored on Log.Write calls if an IPrincipalResolver is set

### DIFF
--- a/src/Agent.Test/SetUp.cs
+++ b/src/Agent.Test/SetUp.cs
@@ -4,9 +4,11 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using Gibraltar.Agent;
+using Gibraltar.Monitor;
 using Loupe.Configuration;
 using NUnit.Framework;
+using Log = Gibraltar.Agent.Log;
+using LogInitializingEventArgs = Gibraltar.Agent.LogInitializingEventArgs;
 
 namespace Loupe.Agent.Test
 {
@@ -69,6 +71,10 @@ namespace Loupe.Agent.Test
             //force us to initialize logging
             Log.StartSession(m_Configuration);
             Trace.TraceInformation("Starting testing at {0} on computer {1}", DateTimeOffset.UtcNow, Log.SessionSummary.HostName);
+
+            //we have to test this before we get into the application user tests and start manipulating the properties.
+            Assert.That(Gibraltar.Monitor.Log.PrincipalResolver, Is.InstanceOf(typeof(DefaultPrincipalResolver)));
+            Assert.That(Log.PrincipalResolver, Is.InstanceOf(typeof(DefaultPrincipalResolver)));
         }
 
         void Log_Initializing(object sender, LogInitializingEventArgs e)

--- a/src/Core/Messaging/Publisher.cs
+++ b/src/Core/Messaging/Publisher.cs
@@ -66,7 +66,7 @@ namespace Gibraltar.Messaging
         /// <remarks>The publisher is a very central class; generally there should be only one per process.
         /// More specifically, there should be a one to one relationship between publisher, packet cache, and 
         /// messengers to ensure integrity of the message output.</remarks>
-        public Publisher(string sessionName, AgentConfiguration configuration, SessionSummary sessionSummary)
+        internal Publisher(string sessionName, AgentConfiguration configuration, SessionSummary sessionSummary, IPrincipalResolver principalResolver, IApplicationUserProvider userProvider)
         {
             if (string.IsNullOrEmpty(sessionName))
             {
@@ -98,7 +98,8 @@ namespace Gibraltar.Messaging
 
             m_MessageQueueMaxLength = Math.Max(configuration.Publisher.MaxQueueLength, 1); //make sure there's no way to get it below 1.
 
-            m_PrincipalResolver = new DefaultPrincipalResolver();
+            m_PrincipalResolver = principalResolver;
+            m_ApplicationUserProvider = userProvider;
 
             //create the thread we use for dispatching messages
             CreateMessageDispatchThread();
@@ -847,8 +848,8 @@ namespace Gibraltar.Messaging
             IPrincipal principal = null;
             if (resolver != null)
             {
-                //and set that user to each packet that wants to track the current user
-                foreach (var packet in packetArray.AsEnumerable().OfType<IUserPacket>())
+                //and set that user to each packet that wants to track the current user (and doesn't have one manually set)
+                foreach (var packet in packetArray.AsEnumerable().OfType<IUserPacket>().Where(p => p.Principal == null))
                 {
                     //we only want to resolve the principal once per block, even if there are multiple messages.
                     if (principal == null)

--- a/src/Core/Monitor/DefaultPrincipalResolver.cs
+++ b/src/Core/Monitor/DefaultPrincipalResolver.cs
@@ -24,7 +24,7 @@ namespace Gibraltar.Monitor
         /// <inheritdoc />
         public bool TryResolveCurrentPrincipal(out IPrincipal principal)
         {
-            principal = ClaimsPrincipal.Current;
+            principal = ClaimsPrincipal.Current; //returns Thread.CurrentPrincipal by default.
 
             if (principal == null && _IsWindows)
             {

--- a/src/Core/Monitor/Log.cs
+++ b/src/Core/Monitor/Log.cs
@@ -78,7 +78,7 @@ namespace Gibraltar.Monitor
         private static Packager s_ActivePackager; //PROTECTED BY LOCK
         private static LocalRepository s_Repository;
         private static IApplicationUserProvider s_ApplicationUserProvider; //PROTECTED BY LOCK
-        private static IPrincipalResolver s_PrincipalResolver; //PROTECTED BY LOCK
+        private static IPrincipalResolver s_PrincipalResolver = new DefaultPrincipalResolver(); //PROTECTED BY LOCK
 
         private static readonly MetricDefinitionCollection s_Metrics = new MetricDefinitionCollection();
 
@@ -1926,7 +1926,7 @@ namespace Gibraltar.Monitor
                                                s_SessionStartInfo.ApplicationVersion,
                                                DateTimeOffset.UtcNow.ToString("yyyy-MM-dd HH-mm-ss", CultureInfo.InvariantCulture));
 
-            s_Publisher = new Publisher(sessionName, s_RunningConfiguration, s_SessionStartInfo);
+            s_Publisher = new Publisher(sessionName, s_RunningConfiguration, s_SessionStartInfo, s_PrincipalResolver, s_ApplicationUserProvider);
 
             //record our session start info right now so we're sure it's the first packet we have.
             Write(s_SessionStartInfo.Packet);


### PR DESCRIPTION
Added explicit unit test to cover this scenario (which was accidentally hidden by the clearing of PrincipalResolver by the unit tests)