### PR TITLE
Modify send on error approach to not require an event subscriber

### DIFF
--- a/src/AspNetCore2.Sandbox/appsettings.json
+++ b/src/AspNetCore2.Sandbox/appsettings.json
@@ -16,6 +16,7 @@
       "ApplicationVersionNumber": "1.0.1"
     },
     "Server": {
+      "AutoSendSessions": true,
       "UseGibraltarService": true,
       "SendAllApplications": true,
       "CustomerName": "Your_Customer_Name"

--- a/src/Core/Messaging/LogMessageNotifyEventArgs.cs
+++ b/src/Core/Messaging/LogMessageNotifyEventArgs.cs
@@ -1,6 +1,7 @@
 ﻿
 using System;
-
+using Gibraltar.Monitor.Serialization;
+using Loupe.Extensibility.Data;
 
 
 namespace Gibraltar.Messaging
@@ -11,13 +12,13 @@ namespace Gibraltar.Messaging
     internal class LogMessageNotifyEventArgs : EventArgs
     {
         /// <summary>
-        /// The IMessengerPacket for the log message being notified about.
+        /// The ILogMessage being notified.
         /// </summary>
-        internal readonly IMessengerPacket Packet;
+        internal readonly LogMessagePacket Message;
 
-        internal LogMessageNotifyEventArgs(IMessengerPacket packet)
+        internal LogMessageNotifyEventArgs(LogMessagePacket message)
         {
-            Packet = packet;
+            Message = message;
         }
     }
 }

--- a/src/Core/Monitor/EventMetricDefinition.cs
+++ b/src/Core/Monitor/EventMetricDefinition.cs
@@ -284,7 +284,7 @@ namespace Gibraltar.Monitor
             {
                 trendable = true;
             }
-                //Now check object types
+            //Now check object types
             else if ((type == typeof(DateTimeOffset)) || (type == typeof(TimeSpan)))
             {
                 trendable = true;

--- a/src/Core/Monitor/EventMetricSample.cs
+++ b/src/Core/Monitor/EventMetricSample.cs
@@ -62,7 +62,8 @@ namespace Gibraltar.Monitor
 #else
                 //log and return, nothing we can do.
                 if (!Log.SilentMode)
-                    Log.Write(LogMessageSeverity.Warning, LogCategory, "Unable to add metric value to the current sample due to missing value definition", "There is no value definition named {1} for metric definition {0}",
+                    Log.Write(LogMessageSeverity.Warning, LogCategory, "Unable to add metric value to the current sample due to missing value definition",
+                        "There is no value definition named {1} for metric definition {0}",
                         Metric.Definition.Name, name);
                 return;
 #endif
@@ -102,7 +103,8 @@ namespace Gibraltar.Monitor
 #else
                 //log and return, nothing we can do.
                 if (!Log.SilentMode)
-                    Log.Write(LogMessageSeverity.Warning, LogCategory, "Unable to add metric value to the current sample due to missing value definition", "There is no value definition named {1} for metric definition {0}",
+                    Log.Write(LogMessageSeverity.Warning, LogCategory, "Unable to add metric value to the current sample due to missing value definition", 
+                        "There is no value definition named {1} for metric definition {0}",
                         Metric.Definition.Name, valueDefinition.Name);
                 return;
 #endif
@@ -166,7 +168,8 @@ namespace Gibraltar.Monitor
 #else
                 //log and return, nothing we can do.
                 if (!Log.SilentMode)
-                    Log.Write(LogMessageSeverity.Warning, LogCategory, "Unable to add metric value to the current sample due to missing value definition","There is no value definition at index {1} for metric definition {0}",
+                    Log.Write(LogMessageSeverity.Warning, LogCategory, "Unable to add metric value to the current sample due to missing value definition",
+                        "There is no value definition at index {1} for metric definition {0}",
                         Metric.Definition.Name, valueIndex);
                 return;
 #endif

--- a/src/Core/Monitor/Log.cs
+++ b/src/Core/Monitor/Log.cs
@@ -317,7 +317,7 @@ namespace Gibraltar.Monitor
                     lock (s_NotifierLock) // Must get the lock to make sure only one thread can try this at a time.
                     {
                         if (s_MessageAlertNotifier == null) // Double-check that it's actually still null.
-                            s_MessageAlertNotifier = new Notifier(LogMessageSeverity.Warning, "Message Alert");
+                            s_MessageAlertNotifier = new Notifier(s_Publisher, LogMessageSeverity.Warning, "Message Alert");
                     }
                 }
 
@@ -337,7 +337,7 @@ namespace Gibraltar.Monitor
                     lock (s_NotifierLock) // Must get the lock to make sure only one thread can try this at a time.
                     {
                         if (s_MessageNotifier == null) // Double-check that it's actually still null.
-                            s_MessageNotifier = new Notifier(LogMessageSeverity.Verbose, "Messages", false);
+                            s_MessageNotifier = new Notifier(s_Publisher, LogMessageSeverity.Verbose, "Messages", false);
                     }
                 }
 
@@ -2022,20 +2022,12 @@ namespace Gibraltar.Monitor
                         }
 
                         publishEngine = s_PublishEngine;
-
-                        if (s_RunningConfiguration.Server.AutoSendOnError)
-                        {
-                            var notifier = MessageAlertNotifier; //poking this creates our background threads.
-                        }
                     }
 
                     System.Threading.Monitor.PulseAll(s_SyncObject);
                 }
 
-                if (publishEngine != null)
-                {
-                    publishEngine.Start();
-                }
+                publishEngine?.Start();
             }
             catch (Exception ex)
             {

--- a/src/Extensions.Logging/LoupeLogger.cs
+++ b/src/Extensions.Logging/LoupeLogger.cs
@@ -16,7 +16,6 @@ namespace Loupe.Extensions.Logging
         /// <summary>
         /// Initializes a new instance of the <see cref="LoupeLogger"/> class.
         /// </summary>
-        /// <param name="category">The category.</param>
         public LoupeLogger(LoupeLoggerProvider provider, string category)
         {
             _provider = provider;
@@ -33,7 +32,7 @@ namespace Loupe.Extensions.Logging
 
             var description = formatter(state, exception);
             var details = LoupeLogEnricher.GetJson(state, _provider);
-            Gibraltar.Agent.Log.Write(severity, "Microsoft.Extensions.Logging", 1, exception, LogWriteMode.Queued, details, _category, null, description, state);
+            Gibraltar.Agent.Log.Write(severity, "Microsoft.Extensions.Logging", 1, exception, LogWriteMode.Queued, details, _category, null, description);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Re-implemented AutoSendOnError to work directly in the Publisher class around the Queue method to the notifiers.  Revised the Notifier implementation to no longer use a static event to the Publisher to further push us along the road to allowing Loupe to be re-initialized while running.