### PR TITLE
Exclude Microsort.Extensions.DiagnosticAdapter in .NET 5

### DIFF
--- a/src/Services/Services.csproj
+++ b/src/Services/Services.csproj
@@ -67,7 +67,6 @@
 				<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
 				<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
 				<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
-				<PackageReference Include="Microsoft.Extensions.DiagnosticAdapter" Version="3.1.10" />
 				<PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
 			</ItemGroup>
 		</Otherwise>


### PR DESCRIPTION
Fix Issue#77 which was caused by using the .NET Core 3.* version of Microsoft.Extensions.DiagnosticAdapter which appears to no longer be supported in .NET 5.