### PR TITLE
Add log messages for web requests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ variables:
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
   major: 4
-  minor: 12
+  minor: 13
   revision: 0
   fileVersion: '$(Build.BuildNumber)'
 

--- a/src/AspNetCore/AspNetCore.csproj
+++ b/src/AspNetCore/AspNetCore.csproj
@@ -98,4 +98,7 @@
 		</ProjectReference>
 		<ProjectReference Include="..\Services\Services.csproj" />
 	</ItemGroup>
+	<ItemGroup>
+	  <Folder Include="Configuration\" />
+	</ItemGroup>
 </Project>

--- a/src/AspNetCore/Extensions.cs
+++ b/src/AspNetCore/Extensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net.Http;
+using System.Reflection;
 using Loupe.Agent.AspNetCore.Infrastructure;
 using Loupe.Agent.AspNetCore.Metrics;
 using Microsoft.AspNetCore.Http;
@@ -72,58 +73,18 @@ namespace Loupe.Agent.AspNetCore
             return valueString;
         }
 
-/*
         /// <summary>
-        /// Store a request metric into the HTTP context for later use
+        /// Read a property from an object by name, typically because it's an anonymous type.
         /// </summary>
-        /// <param name="context"></param>
-        /// <param name="metricTracker"></param>
-        internal static void Store(this HttpContext context, RequestMetric metricTracker)
+        /// <typeparam name="T"></typeparam>
+        /// <param name="anonymousObject"></param>
+        /// <param name="propertyName"></param>
+        /// <returns></returns>
+        internal static T? GetProperty<T>(this object anonymousObject, string propertyName) where T: class
         {
-            string key = HttpContextMetricPrefix + metricTracker.UniqueId;
-            context.Items[key] = metricTracker;
+            return anonymousObject.GetType().GetTypeInfo().GetDeclaredProperty(propertyName)?.GetValue(anonymousObject) as T;
         }
 
-        /// <summary>
-        /// Retrieve a request metric from the HTTP context
-        /// </summary>
-        /// <typeparam name="TMetric">The specific type of request metric to return</typeparam>
-        /// <param name="context">The current HTTP context</param>
-        /// <param name="uniqueId">the unique id of the request to retrieve the metric for</param>
-        /// <returns>The request metric or null if it couldn't be found or was of an incompatible type</returns>
-        internal static TMetric? Retrieve<TMetric>(this HttpContext context, string uniqueId)
-            where TMetric : RequestMetric
-        {
-            if (string.IsNullOrWhiteSpace(uniqueId))
-                throw new ArgumentNullException("uniqueId");
-
-            string key = HttpContextMetricPrefix + uniqueId;
-
-            return context.Items[key] as TMetric;
-        }
-
-        /// <summary>
-        /// Store a request metric into the HTTP context for later use
-        /// </summary>
-        /// <param name="context"></param>
-        /// <param name="metricTracker"></param>
-        internal static void Store(this HttpRequestMessage context, RequestMetric metricTracker)
-        {
-            context.Properties[HttpContextMetricPrefix] = metricTracker;
-        }
-
-        /// <summary>
-        /// Retrieve a request metric from the HTTP context
-        /// </summary>
-        /// <typeparam name="TMetric">The specific type of request metric to return</typeparam>
-        /// <param name="context">The current HTTP context</param>
-        /// <returns>The request metric or null if it couldn't be found or was of an incompatible type</returns>
-        internal static TMetric? Retrieve<TMetric>(this HttpRequestMessage context)
-            where TMetric : RequestMetric
-        {
-            return context.Properties[HttpContextMetricPrefix] as TMetric;
-        }
-*/
 
         internal static string? GetSessionId(this HttpContext context)
         {

--- a/src/AspNetCore/Infrastructure/Constants.cs
+++ b/src/AspNetCore/Infrastructure/Constants.cs
@@ -24,6 +24,7 @@ namespace Loupe.Agent.AspNetCore.Infrastructure {
         public const string AgentSessionId = "LoupeAgentSessionId";
         public const string ClientHeaderName = "loupe-agent-sessionId";
         internal const string LogSystem = "Loupe";
+        internal const string MetricCategory = "Web Site.Requests";
         internal const string Category = "Loupe.AspNet";
     }
 }

--- a/src/AspNetCore/LoupeCookieMiddleware.cs
+++ b/src/AspNetCore/LoupeCookieMiddleware.cs
@@ -20,7 +20,7 @@ namespace Loupe.Agent.AspNetCore
         private readonly RequestDelegate _next;
 
         /// <summary>
-        /// Constructs and instance of <see cref="LoupeMiddleware"/>.
+        /// Constructs and instance of <see cref="LoupeCookieMiddleware"/>.
         /// </summary>
         /// <param name="next"></param>
         /// <param name="loggerFactory"></param>

--- a/src/AspNetCore/LoupeMiddleware.cs
+++ b/src/AspNetCore/LoupeMiddleware.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using Gibraltar.Agent;
 using Gibraltar.Agent.Metrics;
+using Loupe.Agent.AspNetCore.Infrastructure;
 using Loupe.Agent.Core.Services;
 using Loupe.Extensibility.Data;
 using Microsoft.AspNetCore.Hosting;
@@ -41,7 +42,7 @@ namespace Loupe.Agent.AspNetCore
             applicationLifetime.ApplicationStarted.Register(StartSession);
             applicationLifetime.ApplicationStopped.Register(OnApplicationStopping);
 
-            var requestMetricDefinition = DefineRequestMetric(agent.ApplicationName);
+            var requestMetricDefinition = DefineRequestMetric();
             _requestMetric = EventMetric.Register(requestMetricDefinition, null);
         }
 #else
@@ -61,7 +62,7 @@ namespace Loupe.Agent.AspNetCore
             applicationLifetime.ApplicationStarted.Register(StartSession);
             applicationLifetime.ApplicationStopped.Register(OnApplicationStopping);
 
-            var requestMetricDefinition = DefineRequestMetric(agent.ApplicationName);
+            var requestMetricDefinition = DefineRequestMetric();
             _requestMetric = EventMetric.Register(requestMetricDefinition, null);
         }
 #endif
@@ -124,10 +125,10 @@ namespace Loupe.Agent.AspNetCore
             }
         }
 
-        private static EventMetricDefinition DefineRequestMetric(string applicationName)
+        private static EventMetricDefinition DefineRequestMetric()
         {
             
-            var definition = new EventMetricDefinition(applicationName, "AspNetCore", "Request");
+            var definition = new EventMetricDefinition(Constants.LogSystem, Constants.MetricCategory, "Request");
             definition.AddValue("request", typeof(string), SummaryFunction.Count, "Request", "Request",
                 "The query that was executed.");
             definition.AddValue("duration", typeof(TimeSpan), SummaryFunction.Average, "Duration", "Duration",

--- a/src/AspNetCore/Metrics/ActionDiagnosticListener.NetCore2.cs
+++ b/src/AspNetCore/Metrics/ActionDiagnosticListener.NetCore2.cs
@@ -1,9 +1,12 @@
 ﻿#if NETCOREAPP2_1
 using System.Diagnostics;
+using System.Text;
 using Loupe.Agent.Core.Services;
+using Loupe.Configuration;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.DiagnosticAdapter;
+using Microsoft.Extensions.ObjectPool;
 
 namespace Loupe.Agent.AspNetCore.Metrics
 {
@@ -15,6 +18,8 @@ namespace Loupe.Agent.AspNetCore.Metrics
     public class ActionDiagnosticListener : ILoupeDiagnosticListener
     {
         private readonly RequestMetricFactory _actionMetricFactory;
+        private readonly AspNetConfiguration _options;
+        private static readonly ObjectPool<StringBuilder> StringBuilderPool = new DefaultObjectPool<StringBuilder>(new StringBuilderPooledObjectPolicy());
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ActionDiagnosticListener"/> class.
@@ -52,7 +57,7 @@ namespace Loupe.Agent.AspNetCore.Metrics
         [DiagnosticName("Microsoft.AspNetCore.Mvc.BeforeOnActionExecution")]
         public virtual void BeforeOnActionExecution(ActionExecutingContext actionExecutingContext)
         {
-            actionExecutingContext?.HttpContext?.Features.Set(new ControllerMetric(actionExecutingContext));
+            actionExecutingContext?.HttpContext?.Features.Set(new ControllerMetric(_options, StringBuilderPool, actionExecutingContext));
         }
 
         /// <summary>

--- a/src/AspNetCore/Metrics/ActionDiagnosticListener.cs
+++ b/src/AspNetCore/Metrics/ActionDiagnosticListener.cs
@@ -2,13 +2,16 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Reflection;
 using System.Text;
 using Gibraltar.Agent;
 using Loupe.Agent.Core.Services;
+using Loupe.Configuration;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Diagnostics;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.ObjectPool;
 
 namespace Loupe.Agent.AspNetCore.Metrics
 {
@@ -20,6 +23,8 @@ namespace Loupe.Agent.AspNetCore.Metrics
     public class ActionDiagnosticListener : ILoupeDiagnosticListener, IObserver<KeyValuePair<string, object>>
     {
         private readonly RequestMetricFactory _requestMetricFactory;
+        private readonly AspNetConfiguration _options;
+        private static readonly ObjectPool<StringBuilder> StringBuilderPool = new DefaultObjectPool<StringBuilder>(new StringBuilderPooledObjectPolicy());
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ActionDiagnosticListener"/> class.
@@ -28,6 +33,8 @@ namespace Loupe.Agent.AspNetCore.Metrics
         public ActionDiagnosticListener(LoupeAgent agent)
         {
             _requestMetricFactory = new RequestMetricFactory();
+
+            _options = agent.Configuration.AspNet ?? new AspNetConfiguration();
         }
 
         /// <inheritdoc />
@@ -49,63 +56,10 @@ namespace Loupe.Agent.AspNetCore.Metrics
         {
             try
             {
-                switch (value.Value)
+                var processed = ProcessEventsByValueType(value); //these do type comparisons and are fast & frequent
+                if (processed == false)
                 {
-                    case HttpContext httpContext:
-                        HandleHttpContextDiagnostic(httpContext, value.Key);
-                        break;
-                    case BeforeActionEventData beforeActionEventData:
-                        var requestMetric = beforeActionEventData.HttpContext.Features.Get<RequestMetric>();
-                        if (requestMetric == null)
-                            break;
-
-                        ActionMetricBase actionMetric = null;
-
-                        //create the right action metric for our and associate it with our request metric.
-                        switch (beforeActionEventData.ActionDescriptor)
-                        {
-                            case ControllerActionDescriptor controllerActionDescriptor:
-                                actionMetric = new ControllerMetric(beforeActionEventData.HttpContext, controllerActionDescriptor);
-                                break;
-                            case PageActionDescriptor pageActionDescriptor:
-                                actionMetric = new PageMetric(beforeActionEventData.HttpContext, pageActionDescriptor);
-                                break;
-                        }
-
-                        if (actionMetric != null)
-                        {
-                            requestMetric.ActionMetric = actionMetric;
-                        }
-
-                        break;
-                    case AfterActionEventData afterActionEventData:
-                        var metric = afterActionEventData.HttpContext.Features.Get<RequestMetric>();
-
-                        if (metric?.ActionMetric == null) break;
-
-                        metric.ActionMetric.Stop(Activity.Current);
-                        break;
-                    case BeforeAuthorizationFilterOnAuthorizationEventData beforeAuthorization:
-                        beforeAuthorization.AuthorizationContext.HttpContext.Features
-                            .Get<RequestMetric>()?.StartRequestAuthorization();
-                        break;
-                    case AfterAuthorizationFilterOnAuthorizationEventData afterAuthorization:
-                        afterAuthorization.AuthorizationContext.HttpContext.Features
-                            .Get<RequestMetric>()?.StopRequestAuthorization();
-                        break;
-                    case BeforeActionFilterOnActionExecutingEventData beforeActionExecuting:
-                        beforeActionExecuting.ActionExecutingContext.HttpContext.Features
-                            .Get<RequestMetric>()?.StartRequestExecution(beforeActionExecuting.ActionDescriptor.DisplayName
-                            ?? string.Empty);
-                        break;
-                    case AfterActionFilterOnActionExecutedEventData afterActionExecuted:
-                        afterActionExecuted.ActionExecutedContext.HttpContext.Features
-                            .Get<RequestMetric>()?.StopRequestExecution();
-                        break;
-                    case BeforeExceptionFilterOnException onException:
-                        onException.ExceptionContext.HttpContext.Features.Get<RequestMetric>()
-                            ?.SetException(onException.ExceptionContext.Exception);
-                        break;
+                    ProcessEventsByKey(value); //these do string comparisons so are slower.
                 }
             }
             catch (Exception e)
@@ -114,17 +68,130 @@ namespace Loupe.Agent.AspNetCore.Metrics
             }
         }
 
-        private void HandleHttpContextDiagnostic(HttpContext httpContext, string key)
+        /// <summary>
+        /// Process events where we need to switch based on the key, which is slower.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        private bool ProcessEventsByKey(KeyValuePair<string, object> value)
         {
-            switch (key)
+            switch (value.Key)
             {
+                case "Microsoft.AspNetCore.Hosting.UnhandledException": //used when no exception handler is registered in the request pipeline
+                case "Microsoft.AspNetCore.Diagnostics.UnhandledException": //used when an exception handler is registered 
+                case "Microsoft.AspNetCore.Diagnostics.HandledException": //used when an exception handler is registered 
+                {
+                    //This can be made faster, but if we're in an exception flow performance is already not fabulous.
+                    var httpContext = value.Value.GetProperty<HttpContext>("httpContext");
+                    var exception = value.Value.GetProperty<Exception>("exception");
+
+                    if (exception != null)
+                        httpContext?.Features.Get<RequestMetric>()?.SetException(exception);
+                    break;
+                }
                 case "Microsoft.AspNetCore.Hosting.HttpRequestIn.Start":
-                    httpContext.Features.Set(_requestMetricFactory.Start(httpContext));
+                {
+                    var httpContext = value.Value as HttpContext;
+                    httpContext?.Features.Set(_requestMetricFactory.Start(httpContext));
                     break;
+                }
                 case "Microsoft.AspNetCore.Hosting.HttpRequestIn.Stop":
-                    httpContext.Features.Get<RequestMetric>()?.Stop();
+                {
+                    var httpContext = value.Value as HttpContext;
+                    httpContext?.Features.Get<RequestMetric>()?.Stop();
                     break;
+                }
+                default:
+                    return false; //we didn't handle it.
             }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Process events where we can switch by type.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        private bool ProcessEventsByValueType(KeyValuePair<string, object> value)
+        {
+            switch (value.Value)
+            {
+                case BeforeActionEventData beforeActionEventData:
+                    RequestMetric? requestMetric = beforeActionEventData.HttpContext.Features.Get<RequestMetric>();
+                    if (requestMetric == null)
+                        break;
+
+                    ActionMetricBase actionMetric = null;
+
+                    //create the right action metric for our and associate it with our request metric.
+                    switch (beforeActionEventData.ActionDescriptor)
+                    {
+                        case ControllerActionDescriptor controllerActionDescriptor:
+                            actionMetric = new ControllerMetric(_options, StringBuilderPool, beforeActionEventData.HttpContext,
+                                controllerActionDescriptor);
+                            break;
+                        case PageActionDescriptor pageActionDescriptor:
+                            actionMetric = new PageMetric(_options, StringBuilderPool, beforeActionEventData.HttpContext,
+                                pageActionDescriptor);
+                            break;
+                    }
+
+                    if (actionMetric != null)
+                    {
+                        requestMetric.ActionMetric = actionMetric;
+                    }
+
+                    break;
+                case AfterActionEventData afterActionEventData:
+                {
+                    var metric = afterActionEventData.HttpContext.Features.Get<RequestMetric>();
+
+                    if (metric?.ActionMetric == null) break;
+
+                    metric.ActionMetric.Stop(Activity.Current);
+                    break;
+                }
+                case BeforeAuthorizationFilterOnAuthorizationEventData beforeAuthorization:
+                    beforeAuthorization.AuthorizationContext.HttpContext.Features
+                        .Get<RequestMetric>()?.StartRequestAuthorization();
+                    break;
+                case AfterAuthorizationFilterOnAuthorizationEventData afterAuthorization:
+                    afterAuthorization.AuthorizationContext.HttpContext.Features
+                        .Get<RequestMetric>()?.StopRequestAuthorization();
+                    break;
+                case BeforeActionFilterOnActionExecutingEventData beforeActionExecuting:
+                {
+                    var metric = beforeActionExecuting.ActionExecutingContext.HttpContext.Features
+                        .Get<RequestMetric>();
+
+                    if (metric == null) break;
+
+                    if (metric.ActionMetric != null && _options.LogRequests && _options.LogRequestParameters)
+                    {
+                        metric.ActionMetric.SetParameterDetails(beforeActionExecuting.ActionExecutingContext.ActionArguments);
+                    }
+
+                    //since we're about to execute, record the request.
+                    metric.ActionMetric?.RecordRequest();
+
+                    metric.StartRequestExecution(beforeActionExecuting.ActionDescriptor.DisplayName
+                                                 ?? string.Empty);
+                    break;
+                }
+                case AfterActionFilterOnActionExecutedEventData afterActionExecuted:
+                    afterActionExecuted.ActionExecutedContext.HttpContext.Features
+                        .Get<RequestMetric>()?.StopRequestExecution();
+                    break;
+                case BeforeExceptionFilterOnException onException:
+                    onException.ExceptionContext.HttpContext.Features.Get<RequestMetric>()
+                        ?.SetException(onException.ExceptionContext.Exception);
+                    break;
+                default:
+                    return false; //we didn't handle it.
+            }
+
+            return true;
         }
     }
 }

--- a/src/AspNetCore/Metrics/ActionMetricBase.cs
+++ b/src/AspNetCore/Metrics/ActionMetricBase.cs
@@ -88,7 +88,7 @@ namespace Loupe.Agent.AspNetCore.Metrics
             Parameters = StringifyParameterNames(actionExecutingContext.ActionDescriptor.Parameters);
         }
 
-        internal void SetParameterDetails(IDictionary<string, object> actionArguments)
+        internal void SetParameterDetails(IReadOnlyDictionary<string, object> actionArguments)
         {
             if (actionArguments.Count == 0) return;
 

--- a/src/AspNetCore/Metrics/ControllerMetric.cs
+++ b/src/AspNetCore/Metrics/ControllerMetric.cs
@@ -1,38 +1,58 @@
-﻿using Gibraltar.Agent.Metrics;
+﻿using System;
+using System.Buffers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Gibraltar.Agent;
+using Gibraltar.Agent.Metrics;
+using Loupe.Agent.AspNetCore.Infrastructure;
+using Loupe.Configuration;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.ObjectPool;
 
 namespace Loupe.Agent.AspNetCore.Metrics
 {
     /// <summary>
     /// Tracking metric for an ASP.NET controller request
     /// </summary>
-    [EventMetric("Loupe", "Web Site.Requests", "Controller Action", Caption = "Controller Action", 
+    [EventMetric(Constants.LogSystem, Constants.MetricCategory, "Controller Action", Caption = "Controller Action", 
         Description = "Performance data for every controller call in the application")]
     public class ControllerMetric : ActionMetricBase
     {
+        internal const string LogCategory = Constants.Category + ".Controller Request";
+
+        private readonly ObjectPool<StringBuilder> _stringBuilderPool;
+
         /// <summary>
         /// Constructor for .NET Core 3 and later
         /// </summary>
-        /// <param name="httpContext"></param>
-        /// <param name="controllerDescriptor"></param>
-        internal ControllerMetric(HttpContext httpContext, ControllerActionDescriptor controllerDescriptor)
-            :base(httpContext, controllerDescriptor)
+        internal ControllerMetric(AspNetConfiguration options, 
+            ObjectPool<StringBuilder> stringBuilderPool,
+            HttpContext httpContext, 
+            ControllerActionDescriptor controllerDescriptor)
+            :base(options, stringBuilderPool, httpContext, controllerDescriptor)
         {
+            _stringBuilderPool = stringBuilderPool;
             ControllerName = controllerDescriptor.ControllerName;
             ActionName = controllerDescriptor.ActionName;
             ClassName = controllerDescriptor.ControllerTypeInfo?.FullName;
             MethodName = controllerDescriptor.MethodInfo?.Name;
             Request = string.Format("{0}:{1}", ControllerName, ActionName);
+            Path = httpContext.Request.Path;
         }
 
         /// <summary>
         /// Constructor for .NET Core 2
         /// </summary>
-        /// <param name="actionExecutingContext"></param>
-        internal ControllerMetric(ActionExecutingContext actionExecutingContext)
-            :base(actionExecutingContext)
+        internal ControllerMetric(AspNetConfiguration options,
+            ObjectPool<StringBuilder> stringBuilderPool, 
+            ActionExecutingContext actionExecutingContext)
+            :base(options, stringBuilderPool, actionExecutingContext)
         {
             if (actionExecutingContext.ActionDescriptor is ControllerActionDescriptor controllerActionDescriptor)
             {
@@ -42,6 +62,146 @@ namespace Loupe.Agent.AspNetCore.Metrics
                 MethodName = controllerActionDescriptor.MethodInfo?.Name;
             }
         }
+
+        /// <inheritdoc />
+        protected override void OnLogRequest()
+        {
+            var caption = string.Format("Api {0} {1} Requested", ControllerName, ActionName);
+
+            var descriptionBuilder = _stringBuilderPool.Get();
+
+            try
+            {
+
+                if (!string.IsNullOrWhiteSpace(SessionId))
+                {
+                    descriptionBuilder.AppendFormat("SessionId: {0}\r\n", SessionId);
+                }
+
+                if (!string.IsNullOrWhiteSpace(AgentSessionId))
+                {
+                    descriptionBuilder.AppendFormat("JS Agent SessionId: {0}\r\n", AgentSessionId);
+                }
+
+                descriptionBuilder.AppendFormat("Controller: {0}\r\n", ControllerName);
+                descriptionBuilder.AppendFormat("Action: {0}\r\n", ActionName);
+                if (Options.LogRequestParameters && string.IsNullOrEmpty(ParameterDetails) == false)
+                {
+                    descriptionBuilder.AppendLine(ParameterDetails);
+                }
+
+                descriptionBuilder.AppendFormat("Path: {0}\r\n", Path);
+
+                string? detailsJson = null;
+                try
+                {
+                    detailsJson = JsonSerializer.Serialize(this, JsonSerializerOptions);
+                }
+                catch (Exception)
+                {
+                }
+
+                Log.Write((LogMessageSeverity) Options.RequestMessageSeverity, Constants.LogSystem,
+                    (IMessageSourceProvider) this, null, null,
+                    LogWriteMode.Queued, detailsJson, LogCategory, caption, descriptionBuilder.ToString());
+            }
+            finally
+            {
+                _stringBuilderPool.Return(descriptionBuilder);
+            }
+        }
+
+        /// <inheritdoc />
+        protected override void OnLogRequestCompletion()
+        {
+            //wait, we only log if something has gone wrong.
+            if (ResponseCode < 400)
+                return;
+
+            string responseMessage = ReasonPhrases.GetReasonPhrase(ResponseCode);
+
+            LogMessageSeverity severity;
+            string caption;
+            if (ResponseCode < 500)
+            {
+                severity = LogMessageSeverity.Warning;
+                caption = string.Format("Api {0} {1} returning {2} ({3})", ControllerName, ActionName, responseMessage, ResponseCode);
+            }
+            else
+            {
+                severity = LogMessageSeverity.Error;
+
+                if (Exception != null)
+                {
+                    caption = string.Format("Api {0} {1} Failed due to {4} - {2} ({3})", ControllerName, ActionName, responseMessage, ResponseCode,
+                        Exception.GetBaseException().GetType().Name);
+                }
+                else
+                {
+                    caption = string.Format("Api {0} {1} Failed - {2} ({3})", ControllerName, ActionName, responseMessage, ResponseCode);
+                }
+            }
+
+            var descriptionBuilder = _stringBuilderPool.Get();
+
+            try
+            {
+                var reportException = Exception?.GetBaseException();
+                if (reportException != null)
+                {
+                    descriptionBuilder.AppendFormat("{0}\r\n", reportException.Message);
+
+                    var source = reportException.TargetSite;
+                    if (source != null)
+                    {
+                        descriptionBuilder.AppendFormat("Thrown by {0}:{1}\r\n\r\n", source.ReflectedType?.FullName, source.Name);
+                    }
+                }
+
+                if (!string.IsNullOrWhiteSpace(SessionId))
+                {
+                    descriptionBuilder.AppendFormat("SessionId: {0}\r\n", SessionId);
+                }
+
+                if (!string.IsNullOrWhiteSpace(AgentSessionId))
+                {
+                    descriptionBuilder.AppendFormat("JS Agent SessionId: {0}\r\n", AgentSessionId);
+                }
+
+                descriptionBuilder.AppendFormat("Controller: {0}\r\n", ControllerName);
+                descriptionBuilder.AppendFormat("Action: {0}\r\n", ActionName);
+                if (Options.LogRequestParameters && string.IsNullOrEmpty(ParameterDetails) == false)
+                {
+                    descriptionBuilder.AppendLine(ParameterDetails);
+                }
+
+                descriptionBuilder.AppendFormat("Path: {0}\r\n", Path);
+
+                string? detailsJson = null;
+                try
+                {
+                    detailsJson = JsonSerializer.Serialize(this, JsonSerializerOptions);
+                }
+                catch (Exception)
+                {
+                }
+
+                Log.Write(severity, Constants.LogSystem,
+                    (IMessageSourceProvider)this, null, Exception,
+                    LogWriteMode.Queued, detailsJson, LogCategory, caption, descriptionBuilder.ToString());
+            }
+            finally
+            {
+                _stringBuilderPool.Return(descriptionBuilder);
+            }
+        }
+
+        /// <summary>
+        /// The relative path from the application root for the request
+        /// </summary>
+        [EventMetricValue("path", SummaryFunction.Count, null, Caption = "Path", Description = "The relative path from the application root for the page")]
+        [JsonPropertyName("RequestPath")] //Match MEL
+        public string Path { get; }
 
         /// <summary>
         /// Gets/Sets the name of the controller this action belongs to
@@ -59,6 +219,8 @@ namespace Loupe.Agent.AspNetCore.Metrics
         /// The class name of the controller used for the request
         /// </summary>
         [EventMetricValue("class", SummaryFunction.Count, null, Caption = "Class", Description = "The class name of the controller used for the request")]
+        [JsonIgnore]
         public string? TypeFullName => ClassName;
+
     }
 }

--- a/src/AspNetCore/Metrics/PageMetric.cs
+++ b/src/AspNetCore/Metrics/PageMetric.cs
@@ -26,8 +26,9 @@ namespace Loupe.Agent.AspNetCore.Metrics
         internal PageMetric(AspNetConfiguration options,
             ObjectPool<StringBuilder> stringBuilderPool, 
             HttpContext httpContext, 
-            PageActionDescriptor pageDescriptor)
-            : base(options, stringBuilderPool, httpContext, pageDescriptor)
+            PageActionDescriptor pageDescriptor,
+            ActionMetricBase? rootActionMetric)
+            : base(options, stringBuilderPool, httpContext, pageDescriptor, rootActionMetric)
         {
             Path = pageDescriptor.RelativePath;
             AreaName = pageDescriptor.AreaName;

--- a/src/AspNetCore/Metrics/PageMetric.cs
+++ b/src/AspNetCore/Metrics/PageMetric.cs
@@ -4,6 +4,8 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Text;
 using Gibraltar.Agent.Metrics;
+using Loupe.Agent.AspNetCore.Infrastructure;
+using Loupe.Configuration;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -14,17 +16,18 @@ namespace Loupe.Agent.AspNetCore.Metrics
     /// <summary>
     /// Tracking metric for an ASP.NET controller request
     /// </summary>
-    [EventMetric("Loupe", "Web Site.Requests", "Page Action", Caption = "Page Action", 
+    [EventMetric(Constants.LogSystem, Constants.MetricCategory, "Page Action", Caption = "Page Action", 
         Description = "Performance data for every page call in the application")]
     public class PageMetric : ActionMetricBase
     {
         /// <summary>
         /// Constructor for .NET Core 3 and later
         /// </summary>
-        /// <param name="httpContext"></param>
-        /// <param name="pageDescriptor"></param>
-        internal PageMetric(HttpContext httpContext, PageActionDescriptor pageDescriptor)
-            : base(httpContext, pageDescriptor)
+        internal PageMetric(AspNetConfiguration options,
+            ObjectPool<StringBuilder> stringBuilderPool, 
+            HttpContext httpContext, 
+            PageActionDescriptor pageDescriptor)
+            : base(options, stringBuilderPool, httpContext, pageDescriptor)
         {
             Path = pageDescriptor.RelativePath;
             AreaName = pageDescriptor.AreaName;
@@ -32,55 +35,8 @@ namespace Loupe.Agent.AspNetCore.Metrics
             DisplayName = pageDescriptor.DisplayName;
         }
 
-        private static string StringifyParameterNames(IList<ParameterDescriptor> actionDescriptorParameters)
-        {
-            new DefaultObjectPoolProvider().Create<StringBuilder>(new StringBuilderPooledObjectPolicy());
-            int count = actionDescriptorParameters.Count;
-
-            if (count == 0)
-            {
-                return string.Empty;
-            }
-
-            if (count == 1)
-            {
-                return actionDescriptorParameters[0].Name;
-            }
-
-            int length = 0;
-            for (int i = 0; i < count; i++)
-            {
-                length += actionDescriptorParameters[i].Name.Length + 2;
-            }
-
-            var builder = new StringBuilder();
-
-            var buffer = ArrayPool<char>.Shared.Rent(length);
-            try
-            {
-                string name = actionDescriptorParameters[0].Name;
-                name.CopyTo(0, buffer, 0, name.Length);
-                int index = name.Length;
-
-                for (int i = 1; i < count; i++)
-                {
-                    buffer[index++] = ',';
-                    buffer[index++] = ' ';
-                    name = actionDescriptorParameters[i].Name;
-                    name.CopyTo(0, buffer, index, name.Length);
-                    index += name.Length;
-                }
-
-                return new string(buffer, 0, index);
-            }
-            finally
-            {
-                ArrayPool<char>.Shared.Return(buffer);
-            }
-        }
-
         /// <summary>
-        /// Gets/Sets the name of the controller this action belongs to
+        /// The relative path from the application root for the page 
         /// </summary>
         [EventMetricValue("path", SummaryFunction.Count, null, Caption = "Path", Description = "The relative path from the application root for the page")]
         public string Path { get; }
@@ -92,7 +48,7 @@ namespace Loupe.Agent.AspNetCore.Metrics
         public string? AreaName { get; }
 
         /// <summary>
-        /// The area name for this page.
+        /// A display name for the page
         /// </summary>
         [EventMetricValue("displayName", SummaryFunction.Count, null, Caption = "Display Name", Description = "A display name for the page")]
         public string? DisplayName { get; } 

--- a/src/AspNetCore/Metrics/RequestMetricFactory.cs
+++ b/src/AspNetCore/Metrics/RequestMetricFactory.cs
@@ -1,4 +1,5 @@
 ﻿using Gibraltar.Agent.Metrics;
+using Loupe.Agent.AspNetCore.Infrastructure;
 using Microsoft.AspNetCore.Http;
 
 namespace Loupe.Agent.AspNetCore.Metrics
@@ -8,11 +9,9 @@ namespace Loupe.Agent.AspNetCore.Metrics
     /// </summary>
     public class RequestMetricFactory
     {
-        private const string MetricCategory = "Web Site.Requests";
         private const string MetricName = "request";
         private const string MetricCaption = "Request";
         private const string MetricDescription = "Performance tracking data about static content & external requests";
-        private const string MetricSystem = "Gibraltar";
 
         private readonly EventMetric _metric;
 
@@ -37,9 +36,9 @@ namespace Loupe.Agent.AspNetCore.Metrics
 
         private static EventMetricDefinition GetMetricDefinition()
         {
-            if (!EventMetricDefinition.TryGetValue(MetricSystem, MetricCategory, MetricCaption, out var eventMetricDefinition))
+            if (!EventMetricDefinition.TryGetValue(Constants.LogSystem, Constants.MetricCategory, MetricCaption, out var eventMetricDefinition))
             {
-                eventMetricDefinition = new EventMetricDefinition(MetricSystem, MetricCategory, MetricName)
+                eventMetricDefinition = new EventMetricDefinition(Constants.LogSystem, Constants.MetricCategory, MetricName)
                 {
                     Caption = MetricCaption,
                     Description = MetricDescription

--- a/src/Core/Monitor/Monitor.cs
+++ b/src/Core/Monitor/Monitor.cs
@@ -3,7 +3,6 @@ using System.Collections.Concurrent;
 using System.Threading;
 using Gibraltar.Messaging;
 using Gibraltar.Monitor.Net;
-using Loupe.Agent.PerformanceCounters;
 using Loupe.Configuration;
 using Loupe.Extensibility.Data;
 

--- a/src/Extensibility/Configuration/AgentConfiguration.cs
+++ b/src/Extensibility/Configuration/AgentConfiguration.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
-using Loupe.Agent.PerformanceCounters;
 
 namespace Loupe.Configuration
 {
@@ -62,8 +61,7 @@ namespace Loupe.Configuration
         /// </summary>
         public AgentConfiguration()
         {
-            // MR: We've traditionally created these by default so the app can just walk properties to get defaults, but 
-            // is that conventional for .NET Core?  Or should we make them create them.
+            AspNet = new AspNetConfiguration();
             Listener = new ListenerConfiguration();
             NetworkViewer = new NetworkViewerConfiguration();
             Packager = new PackagerConfiguration();
@@ -81,6 +79,7 @@ namespace Loupe.Configuration
         /// <remarks>Inferring this from usage in <c>Gibraltar.Agent.Log</c>.</remarks>
         public AgentConfiguration(AgentConfiguration configuration)
         {
+            AspNet = configuration.AspNet;
             Listener = configuration.Listener;
             NetworkViewer = configuration.NetworkViewer;
             Packager = configuration.Packager;
@@ -121,6 +120,11 @@ namespace Loupe.Configuration
         public NetworkViewerConfiguration NetworkViewer { get; set; }
 
         /// <summary>
+        /// Configures the ASP.NET Agent
+        /// </summary>
+        public AspNetConfiguration AspNet { get; set; }
+
+        /// <summary>
         /// Performance monitoring options
         /// </summary>
         public PerformanceConfiguration Performance { get; set; }
@@ -136,11 +140,17 @@ namespace Loupe.Configuration
         public void Sanitize()
         {
             //we want to force everyone to load and sanitize so we know it's completed.
-            NetworkViewer.Sanitize();
-            Packager.Sanitize();
-            Publisher.Sanitize();
-            SessionFile.Sanitize();
-            Server.Sanitize();
+            NetworkViewer ??= new NetworkViewerConfiguration();
+            Packager ??= new PackagerConfiguration();
+            Publisher ??= new PublisherConfiguration();
+            SessionFile ??= new SessionFileConfiguration();
+            Server ??= new ServerConfiguration();
+
+            NetworkViewer?.Sanitize();
+            Packager?.Sanitize();
+            Publisher?.Sanitize();
+            SessionFile?.Sanitize();
+            Server?.Sanitize();
         }
 
         /// <inheritdoc />

--- a/src/Extensibility/Configuration/AspNetConfiguration.cs
+++ b/src/Extensibility/Configuration/AspNetConfiguration.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Loupe.Extensibility.Data;
+
+namespace Loupe.Configuration
+{
+    /// <summary>
+    /// Options for the Loupe Agent for ASP.NET Core
+    /// </summary>
+    public class AspNetConfiguration
+    {
+        /// <summary>
+        /// Create a new AspNetConfiguration
+        /// </summary>
+        public AspNetConfiguration()
+        {
+            Enabled = true;
+            LogRequests = true;
+            LogRequestMetrics = true;
+            LogRequestParameters = true;
+            LogRequestParameterDetails = false;
+            RequestMessageSeverity = LogMessageSeverity.Information;
+        }
+
+        /// <summary>
+        /// Determines if any agent functionality should be enabled.  Defaults to true.
+        /// </summary>
+        /// <remarks>To disable the entire agent set this option to false.  Even if individual
+        /// options are enabled they will be ignored if this is set to false.</remarks>
+        public bool Enabled { get; set; }
+
+        /// <summary>
+        /// Determines if a log message is written for each request handled by a controller. Defaults to true.
+        /// </summary>
+        public bool LogRequests { get; set; }
+
+        /// <summary>
+        /// Determines if an event metric is written to Loupe for each request handled by a controller. Defaults to true.
+        /// </summary>
+        public bool LogRequestMetrics { get; set; }
+
+        /// <summary>
+        /// Determines if request log messages should include the parameter values used for the request. Defaults to true.
+        /// </summary>
+        public bool LogRequestParameters { get; set; }
+
+        /// <summary>
+        /// Determines if request log messages should include object details. Defaults to false.
+        /// </summary>
+        /// <remarks>This setting has no effect if LogRequestParameters is false.</remarks>
+        public bool LogRequestParameterDetails { get; set; }
+
+        /// <summary>
+        /// The severity used for log messages for the start of each request handled by MVC and Web API. Defaults to Verbose.
+        /// </summary>
+        public LogMessageSeverity RequestMessageSeverity { get; set; }
+    }
+}

--- a/src/Extensibility/Configuration/AspNetConfiguration.cs
+++ b/src/Extensibility/Configuration/AspNetConfiguration.cs
@@ -16,7 +16,9 @@ namespace Loupe.Configuration
         public AspNetConfiguration()
         {
             Enabled = true;
+            LogBadRequests = true;
             LogRequests = true;
+            LogRequestFailures = true;
             LogRequestMetrics = true;
             LogRequestParameters = true;
             LogRequestParameterDetails = false;
@@ -36,6 +38,16 @@ namespace Loupe.Configuration
         public bool LogRequests { get; set; }
 
         /// <summary>
+        /// Determines if a log message is written for each request that returns a 400-series response code.  Defaults to true.
+        /// </summary>
+        public bool LogBadRequests { get; set; }
+
+        /// <summary>
+        /// Determines if a log message is written for each request that returns a 500-series response code or throws an exception.  Defaults to true.
+        /// </summary>
+        public bool LogRequestFailures { get; set; }
+
+        /// <summary>
         /// Determines if an event metric is written to Loupe for each request handled by a controller. Defaults to true.
         /// </summary>
         public bool LogRequestMetrics { get; set; }
@@ -52,7 +64,7 @@ namespace Loupe.Configuration
         public bool LogRequestParameterDetails { get; set; }
 
         /// <summary>
-        /// The severity used for log messages for the start of each request handled by MVC and Web API. Defaults to Verbose.
+        /// The severity used for log messages for the start of each request handled by MVC and Web API. Defaults to Information.
         /// </summary>
         public LogMessageSeverity RequestMessageSeverity { get; set; }
     }

--- a/src/Extensibility/Configuration/PackagerConfiguration.cs
+++ b/src/Extensibility/Configuration/PackagerConfiguration.cs
@@ -25,7 +25,7 @@
         /// <summary>
         /// The key sequence used to pop up the packager.
         /// </summary>
-        public string HotKey { get; set; }
+        public string? HotKey { get; set; }
 
         /// <summary>
         /// When true the user will be allowed to save the package to a file.
@@ -51,13 +51,13 @@
         /// The email address to use as the sender&apos;s address
         /// </summary>
         /// <remarks>If specified, the user will not be given the option to override it.</remarks>
-        public string FromEmailAddress { get; set; }
+        public string? FromEmailAddress { get; set; }
 
         /// <summary>
         /// The address to send the email to.
         /// </summary>
         /// <remarks>If specified, the user will not be given the option to override it.</remarks>
-        public string DestinationEmailAddress { get; set; }
+        public string? DestinationEmailAddress { get; set; }
 
         /// <summary>
         /// The product name to use instead of the current application.
@@ -68,7 +68,7 @@
         /// <para>To limit the package to one application within a product specify the applicationName as well
         /// as the productName.  Specifying just the product name will cause the package to contain all applications
         /// for the specified product.</para></remarks>
-        public string ProductName { get; set; }
+        public string? ProductName { get; set; }
 
         /// <summary>
         /// The application name to use instead of the current application.
@@ -77,7 +77,7 @@
         /// you want to package information for instead of the current application.  If specified, the name
         /// must exactly match the name shown in Loupe for the application.</para>
         /// <para>Application name is ignored if product name is not also specified.</para></remarks>
-        public string ApplicationName { get; set; }
+        public string? ApplicationName { get; set; }
 
 
         /// <summary>

--- a/src/Extensibility/Configuration/PerformanceConfiguration.cs
+++ b/src/Extensibility/Configuration/PerformanceConfiguration.cs
@@ -1,7 +1,7 @@
 ﻿using System.Text;
 using Loupe.Configuration;
 
-namespace Loupe.Agent.PerformanceCounters
+namespace Loupe.Configuration
 {
     /// <summary>
     /// Configuration information for performance monitoring

--- a/src/Extensibility/Configuration/PublisherConfiguration.cs
+++ b/src/Extensibility/Configuration/PublisherConfiguration.cs
@@ -28,7 +28,7 @@ namespace Loupe.Configuration
         /// <remarks>Generally unnecessary for windows services, console apps, and WinForm applications.
         /// Useful for web applications where there is no reasonable way of automatically determining
         /// product name from the assemblies that initiate logging.</remarks>
-        public string ProductName { get; set; }
+        public string? ProductName { get; set; }
 
         /// <summary>
         /// Optional.  A description of the application to include with the session information.
@@ -36,7 +36,7 @@ namespace Loupe.Configuration
         /// <remarks>Generally unnecessary for windows services, console apps, and WinForm applications.
         /// Useful for web applications where there is no reasonable way of automatically determining
         /// application description from the assemblies that initiate logging.</remarks>
-        public string ApplicationDescription { get; set; }
+        public string? ApplicationDescription { get; set; }
 
         /// <summary>
         /// Optional.  The name of the application for logging purposes.
@@ -44,7 +44,7 @@ namespace Loupe.Configuration
         /// <remarks>Generally unnecessary for windows services, console apps, and WinForm applications.
         /// Useful for web applications where there is no reasonable way of automatically determining
         /// product name from the assemblies that initiate logging.</remarks>
-        public string ApplicationName { get; set; }
+        public string? ApplicationName { get; set; }
 
         /// <summary>
         /// Optional.  The ApplicationType to treat the application as, overriding the Agent's automatic determination.
@@ -62,7 +62,7 @@ namespace Loupe.Configuration
         /// <remarks><para>Generally unnecessary for windows services, console apps, and WinForm applications.
         /// Useful for web applications where there is no reasonable way of automatically determining
         /// product name from the assemblies that initiate logging.</para></remarks>
-        public Version ApplicationVersion { get; set; }
+        public Version? ApplicationVersion { get; set; }
 
         /// <summary>
         /// We need this to load from JSON, because there's currently no custom binding
@@ -71,10 +71,10 @@ namespace Loupe.Configuration
         /// <remarks>Added Attributes to hide in IntelliSense.</remarks>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public string ApplicationVersionNumber
+        public string? ApplicationVersionNumber
         {
             get => ApplicationVersion?.ToString();
-            set => ApplicationVersion = Version.Parse(value);
+            set => ApplicationVersion = (value == null) ? null : Version.Parse(value);
         }
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace Loupe.Configuration
         /// indicate the hosting environment. If a value is provided it will be 
         /// carried with the session data to upstream servers and clients.  If the 
         /// corresponding entry does not exist it will be automatically created.</remarks>
-        public string EnvironmentName { get; set; }
+        public string? EnvironmentName { get; set; }
 
         /// <summary>
         /// Optional.  The promotion level of the session.
@@ -93,7 +93,7 @@ namespace Loupe.Configuration
         /// indicate whether it was run in development, staging, or production. 
         /// If a value is provided it will be carried with the session data to upstream servers and clients.  
         /// If the corresponding entry does not exist it will be automatically created.</remarks>
-        public string PromotionLevelName { get; set; }
+        public string? PromotionLevelName { get; set; }
 
         /// <summary>
         /// When true, the publisher will treat all publish requests as write-through requests.

--- a/src/Extensibility/Configuration/ServerConfiguration.cs
+++ b/src/Extensibility/Configuration/ServerConfiguration.cs
@@ -164,12 +164,12 @@ namespace Loupe.Configuration
         /// <remarks>Application keys identify the specific repository and optionally an application environment service
         /// for this session's data to be associated with.  The server administrator can determine by application key
         /// whether to accept the session data or not.</remarks>
-        public string ApplicationKey { get; set; }
+        public string? ApplicationKey { get; set; }
 
         /// <summary>
         /// The unique customer name when using the Gibraltar Loupe Service
         /// </summary>
-        public string CustomerName { get; set; }
+        public string? CustomerName { get; set; }
 
         /// <summary>
         /// Indicates if the Gibraltar Loupe Service should be used instead of a private Loupe Server
@@ -187,7 +187,7 @@ namespace Loupe.Configuration
         /// The full DNS name of the server where the Loupe Server is located
         /// </summary>
         /// <remarks>Only applies to a private Loupe Server.</remarks>
-        public string Server { get; set; }
+        public string? Server { get; set; }
 
         /// <summary>
         ///  An optional port number override for the server
@@ -199,13 +199,13 @@ namespace Loupe.Configuration
         /// The virtual directory on the host for the private Loupe Server
         /// </summary>
         /// <remarks>Only applies to a private Loupe Server.</remarks>
-        public string ApplicationBaseDirectory { get; set; }
+        public string? ApplicationBaseDirectory { get; set; }
 
         /// <summary>
         /// The specific repository on the server to send the session to
         /// </summary>
         /// <remarks>Only applies to a private Loupe Server running Enterprise Edition.</remarks>
-        public string Repository { get; set; }
+        public string? Repository { get; set; }
 
         /// <summary>
         /// Check the current configuration information to see if it's valid for a connection, throwing relevant exceptions if not.

--- a/src/Extensibility/Configuration/SessionFileConfiguration.cs
+++ b/src/Extensibility/Configuration/SessionFileConfiguration.cs
@@ -37,7 +37,7 @@ namespace Loupe.Configuration
         /// The folder to store session files in unless explicitly overridden at runtime.
         /// </summary>
         /// <remarks>If null or empty, files will be stored in a central local application data folder which is the preferred setting.</remarks>
-        public string Folder { get; set; }
+        public string? Folder { get; set; }
 
         /// <summary>
         /// The number of seconds between index updates.

--- a/src/Extensibility/Extensibility.csproj
+++ b/src/Extensibility/Extensibility.csproj
@@ -2,6 +2,8 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0;net461;net5.0</TargetFrameworks>
+		<Nullable>enable</Nullable>
+		<LangVersion>8.0</LangVersion>
 		<PackageId>Loupe.Agent.Core.Extensibility</PackageId>
 		<Version>4.12.0.0</Version>
 		<FileVersion>4.12.0.0</FileVersion>
@@ -34,11 +36,12 @@
 		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
 	</PropertyGroup>
 	<ItemGroup>
-		<None Include="..\assets\loupe-192x192.png" Pack="true" PackagePath="" />
+	  <Compile Remove="Properties\**" />
+	  <EmbeddedResource Remove="Properties\**" />
+	  <None Remove="Properties\**" />
 	</ItemGroup>
-
 	<ItemGroup>
-		<Folder Include="Properties\" />
+		<None Include="..\assets\loupe-192x192.png" Pack="true" PackagePath="" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Services/LoupeAgent.cs
+++ b/src/Services/LoupeAgent.cs
@@ -20,7 +20,6 @@ namespace Loupe.Agent.Core.Services
     public sealed class LoupeAgent : IDisposable
     {
         private readonly IServiceProvider _serviceProvider;
-        private readonly AgentConfiguration _agentConfiguration;
         private readonly LoupeDiagnosticListener _diagnosticListener;
 
 #if NETSTANDARD2_0 || NET461
@@ -38,8 +37,7 @@ namespace Loupe.Agent.Core.Services
             if (options == null) throw new ArgumentNullException(nameof(options));
 
             _serviceProvider = serviceProvider;
-            _agentConfiguration = options.Value;
-            ApplicationName = _agentConfiguration.Packager.ApplicationName;
+            Configuration = options.Value;
             _diagnosticListener = new LoupeDiagnosticListener();
             applicationLifetime.ApplicationStarted.Register(Start);
             applicationLifetime.ApplicationStopped.Register(() => End(SessionStatus.Normal, "ApplicationStopped"));
@@ -59,8 +57,7 @@ namespace Loupe.Agent.Core.Services
             if (options == null) throw new ArgumentNullException(nameof(options));
 
             _serviceProvider = serviceProvider;
-            _agentConfiguration = options.Value;
-            ApplicationName = _agentConfiguration.Packager.ApplicationName;
+            Configuration = options.Value;
             _diagnosticListener = new LoupeDiagnosticListener();
             applicationLifetime.ApplicationStarted.Register(Start);
             applicationLifetime.ApplicationStopped.Register(() => End(SessionStatus.Normal, "ApplicationStopped"));
@@ -69,7 +66,7 @@ namespace Loupe.Agent.Core.Services
         /// <summary>Starts this Agent instance.</summary>
         public void Start()
         {
-            Log.StartSession(_agentConfiguration);
+            Log.StartSession(Configuration);
             foreach (var listener in _serviceProvider.GetServices<ILoupeDiagnosticListener>())
             {
                 _diagnosticListener.Add(listener);
@@ -99,6 +96,11 @@ namespace Loupe.Agent.Core.Services
             }
         }
 
+        /// <summary>
+        /// The configuration used for the Loupe Agent
+        /// </summary>
+        public AgentConfiguration Configuration { get; }
+
         /// <summary>Stops this Agent instance.</summary>
         /// <param name="status">The session status.</param>
         /// <param name="reason">The reason.</param>
@@ -112,9 +114,5 @@ namespace Loupe.Agent.Core.Services
         {
             _diagnosticListener.Dispose();
         }
-
-        /// <summary>Gets the name of the application.</summary>
-        /// <value>The name of the application.</value>
-        public string ApplicationName { get; }
     }
 }

--- a/src/Services/ServicesExtensions.cs
+++ b/src/Services/ServicesExtensions.cs
@@ -96,14 +96,6 @@ namespace Loupe.Agent.Core.Services
                 {
                     configuration.Bind("Loupe", options);
                     callback?.Invoke(options);
-                    if (options.Packager == null)
-                    {
-                        options.Packager = new PackagerConfiguration {ApplicationName = hostingEnvironment.ApplicationName};
-                    }
-                    else if (options.Packager.ApplicationName == null)
-                    {
-                        options.Packager.ApplicationName = hostingEnvironment.ApplicationName;
-                    }
                 });
 #else
             // Set up options for AgentConfiguration with callback and default ApplicationName from IHostingEnvironment
@@ -112,14 +104,6 @@ namespace Loupe.Agent.Core.Services
                 {
                     configuration.Bind("Loupe", options);
                     callback?.Invoke(options);
-                    if (options.Packager == null)
-                    {
-                        options.Packager = new PackagerConfiguration { ApplicationName = hostEnvironment.ApplicationName };
-                    }
-                    else if (options.Packager.ApplicationName == null)
-                    {
-                        options.Packager.ApplicationName = hostEnvironment.ApplicationName;
-                    }
                 });
 #endif
         }

--- a/src/test/MvcTestApp5/Controllers/AuthorsController.cs
+++ b/src/test/MvcTestApp5/Controllers/AuthorsController.cs
@@ -45,7 +45,11 @@ namespace MvcTestApp5.Controllers
 
             if (author == null)
             {
-                throw new ArgumentOutOfRangeException("unable to find author by key");
+                //just for demo purposes..
+                if (key == 5)
+                    throw new ArgumentOutOfRangeException("unable to find author by key");
+
+                //but this is a more appropriate response.
                 return NotFound(key);
             }
 

--- a/src/test/MvcTestApp5/Properties/launchSettings.json
+++ b/src/test/MvcTestApp5/Properties/launchSettings.json
@@ -4,7 +4,7 @@
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Test"
       },
       "dotnetRunMessages": "true",
       "applicationUrl": "https://localhost:5001;http://localhost:5000"


### PR DESCRIPTION
Users have requested getting simple log messages on request start and request failure.  The built-in ASP.NET logging is reported to be too granular to leave enabled (it writes many messages each with a little detail)