### PR TITLE
Fix cross-domain cookie handling

### DIFF
--- a/src/AspNetCore/AppBuilderExtensions.cs
+++ b/src/AspNetCore/AppBuilderExtensions.cs
@@ -15,10 +15,38 @@ namespace Loupe.Agent.AspNetCore
         /// Add a Loupe middleware to time requests and log errors.
         /// </summary>
         public static IApplicationBuilder UseLoupe(this IApplicationBuilder app) => app.UseMiddleware<LoupeMiddleware>();
-        
+
         /// <summary>
         /// Add Loupe session cookies to all requests
         /// </summary>
-        public static IApplicationBuilder UseLoupeCookies(this IApplicationBuilder app) => app.UseMiddleware<LoupeCookieMiddleware>();
+        /// <remarks>
+        /// Loupe defaults to using a Session cookie with HttpOnly, Secure, and SameSite = None
+        /// which works with Cross-Origin requests. If this does not work, use the
+        /// <see cref="UseLoupeCookies(Microsoft.AspNetCore.Builder.IApplicationBuilder, Microsoft.AspNetCore.Http.CookieOptions)"/>
+        /// overload to specify your own cookie settings.
+        /// </remarks>
+        public static IApplicationBuilder UseLoupeCookies(this IApplicationBuilder app)
+            => UseLoupeCookies(app, null);
+
+        /// <summary>
+        /// Add Loupe session cookies to all requests
+        /// </summary>
+        /// <param name="cookieOptions">Override the default cookie options</param>
+        /// <remarks>
+        /// Loupe defaults to using a Session cookie with HttpOnly, Secure, and SameSite = None
+        /// which works with Cross-Origin requests.
+        /// </remarks>
+        public static IApplicationBuilder UseLoupeCookies(this IApplicationBuilder app, CookieOptions? cookieOptions)
+            => app.UseMiddleware<LoupeCookieMiddleware>(cookieOptions ?? DefaultCookieOptions());
+
+        // As of Chrome v80, SameSite defaults to Lax, which won't set the cookie cross-domain
+        // Explicitly setting SameSite to None requires the Secure flag to be set too
+        private static CookieOptions DefaultCookieOptions() =>
+            new CookieOptions
+            {
+                HttpOnly = true,
+                SameSite = SameSiteMode.None,
+                Secure = true,
+            };
     }
 }

--- a/src/AspNetCore/Extensions.cs
+++ b/src/AspNetCore/Extensions.cs
@@ -88,7 +88,7 @@ namespace Loupe.Agent.AspNetCore
 
         internal static string? GetSessionId(this HttpContext context)
         {
-            return context.Items[Constants.SessionId] as string;
+            return context.Items[Constants.SessionIdCookie] as string;
     
         }
 

--- a/src/AspNetCore/Handlers/HttpRequestExtensions.cs
+++ b/src/AspNetCore/Handlers/HttpRequestExtensions.cs
@@ -14,8 +14,8 @@ namespace Loupe.Agent.AspNetCore.Handlers
         };
 
         public static bool IsInteresting(this HttpRequest request) =>
-            !request.Headers.ContainsKey("Origin")
-            && ValidExtensions.Contains(PathExtension(request))
+            // !request.Headers.ContainsKey("Origin")
+            ValidExtensions.Contains(PathExtension(request))
             && !IsBrowserLink(request);
         
         private static bool IsBrowserLink(HttpRequest request) =>

--- a/src/AspNetCore/Infrastructure/Constants.cs
+++ b/src/AspNetCore/Infrastructure/Constants.cs
@@ -20,7 +20,9 @@
 
 namespace Loupe.Agent.AspNetCore.Infrastructure {
     internal class Constants {
-        public const string SessionId = "LoupeSessionId";
+        public const string SessionIdKey = "LoupeSessionId";
+        public const string SessionIdCookie = "LoupeSessionId";
+        public const string SessionIdHeaderName = "loupe-sessionid";
         public const string AgentSessionId = "LoupeAgentSessionId";
         public const string ClientHeaderName = "loupe-agent-sessionId";
         internal const string LogSystem = "Loupe";

--- a/src/AspNetCore/Infrastructure/RequestProcessor.cs
+++ b/src/AspNetCore/Infrastructure/RequestProcessor.cs
@@ -69,7 +69,7 @@ namespace Loupe.Agent.AspNetCore.Infrastructure
 
         private void CacheClientDetails(HttpContext context, LogRequest logRequest)
         {
-            if (context.Items[Constants.SessionId] is string sessionId && logRequest.Session?.Client != null)
+            if (context.Items[Constants.SessionIdCookie] is string sessionId && logRequest.Session?.Client != null)
             {
                 var clientDetailsBuilder = new ClientDetailsBuilder();
 
@@ -83,7 +83,7 @@ namespace Loupe.Agent.AspNetCore.Infrastructure
 
         private void AddSessionId(HttpContext context, LogRequest logRequest)
         {
-            var sessionId = context.Items[Constants.SessionId] as string;
+            var sessionId = context.Items[Constants.SessionIdCookie] as string;
             var agentSessionId = context.Items[Constants.AgentSessionId] as string;
 
             if (string.IsNullOrWhiteSpace(agentSessionId) && logRequest.Session != null &&

--- a/src/AspNetCore/LoupeCookieMiddleware.cs
+++ b/src/AspNetCore/LoupeCookieMiddleware.cs
@@ -18,6 +18,7 @@ namespace Loupe.Agent.AspNetCore
     {
         private readonly ILoggerFactory? _loggerFactory;
         private readonly RequestDelegate _next;
+        private readonly CookieOptions? _cookieOptions;
 
         /// <summary>
         /// Constructs and instance of <see cref="LoupeCookieMiddleware"/>.
@@ -25,10 +26,11 @@ namespace Loupe.Agent.AspNetCore
         /// <param name="next"></param>
         /// <param name="loggerFactory"></param>
         /// <exception cref="ArgumentNullException"></exception>
-        public LoupeCookieMiddleware(RequestDelegate next, ILoggerFactory? loggerFactory = null)
+        public LoupeCookieMiddleware(RequestDelegate next, CookieOptions? cookieOptions, ILoggerFactory? loggerFactory = null)
         {
             _loggerFactory = loggerFactory;
             _next = next ?? throw new ArgumentNullException(nameof(next));
+            _cookieOptions = cookieOptions;
         }
 
         /// <summary>
@@ -43,7 +45,7 @@ namespace Loupe.Agent.AspNetCore
             {
                 if (context.Request.IsInteresting())
                 {
-                    var sessionId = CookieHandler.GetSessionId(context);
+                    var sessionId = CookieHandler.GetSessionId(context, _cookieOptions);
                     var agentSessionId = HeaderHandler.GetAgentSessionId(context);
 
                     //only grab session ids if we could possibly log them...
@@ -54,7 +56,7 @@ namespace Loupe.Agent.AspNetCore
                         if (!string.IsNullOrEmpty(sessionId))
                         {
                             requestProperties ??= new List<KeyValuePair<string, object>>();
-                            requestProperties.Add(new KeyValuePair<string, object>(Constants.SessionId, sessionId));
+                            requestProperties.Add(new KeyValuePair<string, object>(Constants.SessionIdCookie, sessionId));
                         }
 
                         if (!string.IsNullOrEmpty(agentSessionId))


### PR DESCRIPTION
- The Session ID cookie now defaults to:
  - HttpOnly (not visible to scripts)
  - Secure (only set over HTTPS)
  - SameSite = None (for CORS compatibility)
- Added an overload to `AddLoupeCookies` that takes a `CookieOptions` object to override defaults

There's a `Request.IsInteresting` extension methods which was returning `false` if the `Origin` header was set, which makes no sense so I've removed that check.

Obviously the change to the default cookie settings will stop the cookie being set at all if people are running on HTTP connections, or if their proxy or load balancer is not correctly passing an `X-Forwarded-For` header, so something should be added to the docs to mention this.