### PR TITLE
Expose EF Core listener directly and fix IServiceCollection extension methods

### DIFF
--- a/src/Agent/Agent.csproj
+++ b/src/Agent/Agent.csproj
@@ -4,9 +4,9 @@
 		<TargetFrameworks>netstandard2.0;net461;net5.0</TargetFrameworks>
 		<LangVersion>8.0</LangVersion>
 		<PackageId>Loupe.Agent.Core</PackageId>
-		<Version>4.12.0.0</Version>
-		<FileVersion>4.12.0.0</FileVersion>
-		<AssemblyVersion>4.12.0.0</AssemblyVersion>
+		<Version>4.13.0.0</Version>
+		<FileVersion>4.13.0.0</FileVersion>
+		<AssemblyVersion>4.13.0.0</AssemblyVersion>
 		<Company>Gibraltar Software, Inc.</Company>
 		<Authors>Gibraltar Software, Inc.</Authors>
 		<Product>Loupe</Product>
@@ -29,6 +29,7 @@
 		<DelaySign>false</DelaySign>
 		<AssemblyOriginatorKeyFile>..\..\loupe.agent.snk</AssemblyOriginatorKeyFile>
 		<PackageTags>Loupe,Logging,diagnostics</PackageTags>
+		<CheckEolTargetFramework>false</CheckEolTargetFramework>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
 		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>

--- a/src/AspNetCore/AspNetCore.csproj
+++ b/src/AspNetCore/AspNetCore.csproj
@@ -5,9 +5,9 @@
 		<AssemblyName>Loupe.Agent.AspNetCore</AssemblyName>
 		<RootNamespace>Loupe.Agent.AspNetCore</RootNamespace>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<Version>4.12.0.0</Version>
-		<FileVersion>4.12.0.0</FileVersion>
-		<AssemblyVersion>4.12.0.0</AssemblyVersion>
+		<Version>4.13.0.0</Version>
+		<FileVersion>4.13.0.0</FileVersion>
+		<AssemblyVersion>4.13.0.0</AssemblyVersion>
 		<Authors>Gibraltar Software, Inc.</Authors>
 		<Company>Gibraltar Software, Inc.</Company>
 		<Product>Loupe</Product>
@@ -29,6 +29,7 @@
 		<DocumentationFile>bin\Loupe.Agent.AspNetCore.xml</DocumentationFile>
 		<Nullable>enable</Nullable>
 		<PackageTags>Loupe,logging,diagnostics,aspnetcore</PackageTags>
+		<CheckEolTargetFramework>false</CheckEolTargetFramework>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
 		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -3,9 +3,9 @@
 		<TargetFrameworks>netstandard2.0;netstandard2.1;net461;net462;net47;net471;net472;net48;net5.0;</TargetFrameworks>
 		<AssemblyName>Loupe.Core.NETCore</AssemblyName>
 		<RootNamespace>Gibraltar</RootNamespace>
-		<Version>4.12.0.0</Version>
-		<FileVersion>4.12.0.0</FileVersion>
-		<AssemblyVersion>4.12.0.0</AssemblyVersion>
+		<Version>4.13.0.0</Version>
+		<FileVersion>4.13.0.0</FileVersion>
+		<AssemblyVersion>4.13.0.0</AssemblyVersion>
 		<Copyright>Copyright © 2008-2021 Gibraltar Software, Inc.</Copyright>
 		<Description>Internal functionality for the Loupe Agent for .NET Core.  Add Loupe.Agent.Core to your project to use Loupe.</Description>
 		<Product>Loupe</Product>
@@ -29,6 +29,7 @@
 		<PackageIcon>loupe-192x192.png</PackageIcon>
 		<DocumentationFile>bin\Loupe.Core.NETCore.xml</DocumentationFile>
 		<PackageTags>Loupe,logging,diagnostics</PackageTags>
+	  <CheckEolTargetFramework>false</CheckEolTargetFramework>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
 		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>

--- a/src/Core/Data/Internal/RepositoryPublishClient.cs
+++ b/src/Core/Data/Internal/RepositoryPublishClient.cs
@@ -500,7 +500,7 @@ namespace Gibraltar.Data.Internal
             await m_HubConnection.ExecuteRequest(uploadRequest, -1).ConfigureAwait(false);
 
             //and if we were successful (must have been - we got to here) then mark the session as not being new any more.
-            m_SourceRepository.SetSessionsNew(new[] { sessionId }, false);
+            m_SourceRepository.SetSessionNew(sessionId, false);
         }
 
         /// <summary>

--- a/src/Core/Data/Packager.cs
+++ b/src/Core/Data/Packager.cs
@@ -1369,7 +1369,7 @@ namespace Gibraltar.Data
                                         var localRepository = publishClient.Repository;
                                         try
                                         {
-                                            localRepository.SetSessionsNew(new[] { session.Id }, false);
+                                            localRepository.SetSessionNew(session.Id, false);
                                         }
                                         catch (Exception ex)
                                         {

--- a/src/EFCore2/EFCore2.csproj
+++ b/src/EFCore2/EFCore2.csproj
@@ -4,9 +4,9 @@
 		<LangVersion>8.0</LangVersion>
 		<AssemblyName>Loupe.Agent.EntityFrameworkCore</AssemblyName>
 		<RootNamespace>Loupe.Agent.EntityFrameworkCore</RootNamespace>
-		<Version>4.12.0.0</Version>
-		<FileVersion>4.12.0.0</FileVersion>
-		<AssemblyVersion>4.12.0.0</AssemblyVersion>
+		<Version>4.13.0.0</Version>
+		<FileVersion>4.13.0.0</FileVersion>
+		<AssemblyVersion>4.13.0.0</AssemblyVersion>
 		<Authors>Gibraltar Software, Inc.</Authors>
 		<Product>Loupe</Product>
 		<Copyright>Copyright © 2008-2021 Gibraltar Software, Inc.</Copyright>
@@ -27,6 +27,7 @@
 		<AssemblyOriginatorKeyFile>..\..\loupe.agent.snk</AssemblyOriginatorKeyFile>
 		<DocumentationFile>bin\Loupe.Agent.EntityFrameworkCore.xml</DocumentationFile>
 		<PackageTags>Loupe,entity-framework-core,EFCore,logging,diagnostics</PackageTags>
+		<CheckEolTargetFramework>false</CheckEolTargetFramework>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
 		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>

--- a/src/EFCore2/EntityFrameworkCoreDiagnosticListener.cs
+++ b/src/EFCore2/EntityFrameworkCoreDiagnosticListener.cs
@@ -20,7 +20,7 @@ namespace Loupe.Agent.EntityFrameworkCore
     /// Diagnostic listener for EF Core events.
     /// </summary>
     /// <seealso cref="Loupe.Agent.Core.Services.ILoupeDiagnosticListener" />
-    internal class EntityFrameworkCoreDiagnosticListener : ILoupeDiagnosticListener, IObserver<KeyValuePair<string, object>>
+    public class EntityFrameworkCoreDiagnosticListener : ILoupeDiagnosticListener, IObserver<KeyValuePair<string, object>>
     {
         private const string LogSystem = "Loupe";
         private const string LogCategory = EntityFrameworkConfiguration.LogCategory + ".Query";

--- a/src/Extensibility/Configuration/ServerConfiguration.cs
+++ b/src/Extensibility/Configuration/ServerConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 
 namespace Loupe.Configuration
 {
@@ -306,13 +307,39 @@ namespace Loupe.Configuration
         /// <inheritdoc />
         public override string ToString()
         {
+            var stringBuilder = new StringBuilder();
+
             if (UseGibraltarService)
-                return string.Format("Loupe Cloud-Hosted Subscription '{0}'", CustomerName);
+            {
 
-            if (string.IsNullOrWhiteSpace(Repository))
-                return string.Format("Loupe Server '{0}'", Server);
+                stringBuilder.AppendFormat("\tLoupe Cloud-Hosted Subscription '{0}'\r\n", CustomerName);
+            }
+            else
+            {
+                if (string.IsNullOrWhiteSpace(Repository))
+                {
+                    stringBuilder.AppendFormat("\tLoupe Server '{0}'", Server);
+                }
+                else
+                {
+                    stringBuilder.AppendFormat("\tLoupe Server '{0}' repository '{1}'", Server, Repository);
+                }
+                stringBuilder.AppendFormat("\tUse Ssl: {0}\r\n", UseSsl);
 
-            return string.Format("Loupe Server '{0}' repository '{1}'", Server, Repository);
+                if (Port != 0)
+                    stringBuilder.AppendFormat("\tPort: {0}\r\n", Port);
+            }
+
+            if (string.IsNullOrEmpty(ApplicationKey) == false)
+                stringBuilder.AppendFormat("\tApplication Key: {0}\r\n", ApplicationKey);
+
+            stringBuilder.AppendFormat("\tAuto Send Sessions: {0}\r\n", AutoSendSessions);
+            stringBuilder.AppendFormat("\tSend All Applications: {0}\r\n", SendAllApplications);
+            stringBuilder.AppendFormat("\tPurge Sent Sessions: {0}\r\n", PurgeSentSessions);
+
+            stringBuilder.AppendFormat("\tAuto Send On Error: {0}\r\n", AutoSendOnError);
+
+            return stringBuilder.ToString();
         }
     }
 }

--- a/src/Extensibility/Extensibility.csproj
+++ b/src/Extensibility/Extensibility.csproj
@@ -5,9 +5,9 @@
 		<Nullable>enable</Nullable>
 		<LangVersion>8.0</LangVersion>
 		<PackageId>Loupe.Agent.Core.Extensibility</PackageId>
-		<Version>4.12.0.0</Version>
-		<FileVersion>4.12.0.0</FileVersion>
-		<AssemblyVersion>4.12.0.0</AssemblyVersion>
+		<Version>4.13.0.0</Version>
+		<FileVersion>4.13.0.0</FileVersion>
+		<AssemblyVersion>4.13.0.0</AssemblyVersion>
 		<Authors>Gibraltar Software, Inc.</Authors>
 		<Product>Loupe</Product>
 		<Description>Shared types for the Loupe Agent for .NET Core.  Add Loupe.Agent.Core to your project to use Loupe.</Description>
@@ -31,6 +31,7 @@
 		<AssemblyOriginatorKeyFile>..\..\loupe.agent.snk</AssemblyOriginatorKeyFile>
 		<DocumentationFile>bin\Loupe.Extensibility.NETCore.xml</DocumentationFile>
 		<PackageTags>Loupe</PackageTags>
+		<CheckEolTargetFramework>false</CheckEolTargetFramework>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
 		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>

--- a/src/Extensions.Logging/Extensions.Logging.csproj
+++ b/src/Extensions.Logging/Extensions.Logging.csproj
@@ -5,9 +5,9 @@
 		<AssemblyName>Loupe.Extensions.Logging</AssemblyName>
 		<RootNamespace>Loupe.Extensions.Logging</RootNamespace>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<Version>4.12.0.0</Version>
-		<FileVersion>4.12.0.0</FileVersion>
-		<AssemblyVersion>4.12.0.0</AssemblyVersion>
+		<Version>4.13.0.0</Version>
+		<FileVersion>4.13.0.0</FileVersion>
+		<AssemblyVersion>4.13.0.0</AssemblyVersion>
 		<Authors>Gibraltar Software, Inc.</Authors>
 		<Company>Gibraltar Software, Inc.</Company>
 		<Product>Loupe</Product>
@@ -28,6 +28,7 @@
 		<AssemblyOriginatorKeyFile>..\..\loupe.agent.snk</AssemblyOriginatorKeyFile>
 		<DocumentationFile>bin\Loupe.Extensions.Logging.xml</DocumentationFile>
 		<PackageTags>Loupe,logging,diagnostics</PackageTags>
+		<CheckEolTargetFramework>false</CheckEolTargetFramework>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
 		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>

--- a/src/Packager/Packager.csproj
+++ b/src/Packager/Packager.csproj
@@ -5,9 +5,9 @@
 		<TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net5.0</TargetFrameworks>
 		<AssemblyName>Loupe.Packager</AssemblyName>
 		<RootNamespace>Loupe.Packager</RootNamespace>
-		<Version>4.12.0.0</Version>
-		<FileVersion>4.12.0.0</FileVersion>
-		<AssemblyVersion>4.12.0.0</AssemblyVersion>
+		<Version>4.13.0.0</Version>
+		<FileVersion>4.13.0.0</FileVersion>
+		<AssemblyVersion>4.13.0.0</AssemblyVersion>
 		<Authors>Gibraltar Software, Inc.</Authors>
 		<Company>Gibraltar Software, Inc.Gibraltar Software, Inc.</Company>
 		<Product>Loupe</Product>
@@ -29,6 +29,7 @@
 		<DelaySign>false</DelaySign>
 		<AssemblyOriginatorKeyFile>..\..\loupe.agent.snk</AssemblyOriginatorKeyFile>
 		<PackageTags>Loupe</PackageTags>
+		<CheckEolTargetFramework>false</CheckEolTargetFramework>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
 		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>

--- a/src/PerformanceCounters/PerformanceCounters.csproj
+++ b/src/PerformanceCounters/PerformanceCounters.csproj
@@ -5,9 +5,9 @@
 		<AssemblyName>Loupe.Agent.PerformanceCounters</AssemblyName>
 		<RootNamespace>Loupe.Agent.PerformanceCounters</RootNamespace>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<Version>4.12.0.0</Version>
-		<FileVersion>4.12.0.0</FileVersion>
-		<AssemblyVersion>4.12.0.0</AssemblyVersion>
+		<Version>4.13.0.0</Version>
+		<FileVersion>4.13.0.0</FileVersion>
+		<AssemblyVersion>4.13.0.0</AssemblyVersion>
 		<Authors>Gibraltar Software, Inc.</Authors>
 		<Product>Loupe</Product>
 		<Copyright>Copyright © 2008-2021 Gibraltar Software, Inc.</Copyright>
@@ -26,6 +26,7 @@
 		<AssemblyOriginatorKeyFile>..\..\loupe.agent.snk</AssemblyOriginatorKeyFile>
 		<DocumentationFile>bin\Loupe.Agent.PerformanceCounters.xml</DocumentationFile>
 		<PackageTags>Loupe,diagnostics,performance</PackageTags>
+		<CheckEolTargetFramework>false</CheckEolTargetFramework>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
 		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>

--- a/src/Services/Services.csproj
+++ b/src/Services/Services.csproj
@@ -4,9 +4,9 @@
 		<LangVersion>latest</LangVersion>
 		<AssemblyName>Loupe.Agent.Core.Services</AssemblyName>
 		<RootNamespace>Loupe.Agent.Core.Services</RootNamespace>
-		<Version>4.12.0.0</Version>
-		<FileVersion>4.12.0.0</FileVersion>
-		<AssemblyVersion>4.12.0.0</AssemblyVersion>
+		<Version>4.13.0.0</Version>
+		<FileVersion>4.13.0.0</FileVersion>
+		<AssemblyVersion>4.13.0.0</AssemblyVersion>
 		<Company>Gibraltar Software, Inc.</Company>
 		<Authors>Gibraltar Software, Inc.</Authors>
 		<Product>Loupe</Product>
@@ -28,6 +28,7 @@
 		<AssemblyOriginatorKeyFile>..\..\loupe.agent.snk</AssemblyOriginatorKeyFile>
 		<DocumentationFile>bin\Loupe.Agent.Core.Services.xml</DocumentationFile>
 		<PackageTags>Loupe</PackageTags>
+		<CheckEolTargetFramework>false</CheckEolTargetFramework>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
 		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>

--- a/src/Services/ServicesExtensions.cs
+++ b/src/Services/ServicesExtensions.cs
@@ -12,6 +12,7 @@ namespace Loupe.Agent.Core.Services
     /// </summary>
     public static class ServicesExtensions
     {
+        /*
         /// <summary>
         /// Adds Loupe to the services with a configuration callback.
         /// </summary>
@@ -27,16 +28,56 @@ namespace Loupe.Agent.Core.Services
         }
 
         /// <summary>
-        /// Adds Loupe to the services with a configuration callback.
+        /// Adds Loupe to the services collection.
         /// </summary>
         /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <returns>An instance of <see cref="ILoupeAgentBuilder"/> for further customization.</returns>
+        [Obsolete("Returns nonstandard type")]
         public static ILoupeAgentBuilder AddLoupe(this IServiceCollection services)
         {
             AddOptions(services);
             services.AddSingleton<IHostedService, LoupeAgentService>();
             services.AddSingleton<LoupeAgent>();
             return new LoupeAgentServicesCollectionBuilder(services);
+        }
+        */
+
+        /// <summary>
+        /// Adds Loupe to the services collection.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="configure">Optional.  An Agent configuration delegate</param>
+        /// <returns>The modified <see cref="IServiceCollection"/></returns>
+        public static IServiceCollection AddLoupe(this IServiceCollection services, Action<AgentConfiguration> configure = null)
+        {
+            AddOptions(services, configure);
+            services.AddSingleton<IHostedService, LoupeAgentService>();
+            services.AddSingleton<LoupeAgent>();
+
+            return services;
+        }
+
+        /// <summary>
+        /// Adds Loupe to the services collection.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="agentBuilder">The <see cref="ILoupeAgentBuilder"/> delegate for further customization.</param>
+        /// <param name="configure">Optional.  An Agent configuration delegate</param>
+        /// <returns>The modified <see cref="IServiceCollection"/></returns>
+        public static IServiceCollection AddLoupe(this IServiceCollection services,
+            Action<ILoupeAgentBuilder> agentBuilder, Action<AgentConfiguration> configure = null)
+        {
+            AddOptions(services, configure);
+            services.AddSingleton<IHostedService, LoupeAgentService>();
+            services.AddSingleton<LoupeAgent>();
+
+            if (agentBuilder != null)
+            {
+                var agentServices = new LoupeAgentServicesCollectionBuilder(services);
+                agentBuilder(agentServices);
+            }
+
+            return services;
         }
 
 #if !NETSTANDARD2_0 && !NET461

--- a/src/test/AspNetCore2.Sandbox/AspNetCore2.Sandbox.csproj
+++ b/src/test/AspNetCore2.Sandbox/AspNetCore2.Sandbox.csproj
@@ -5,6 +5,7 @@
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <UserSecretsId>89f933bb-882f-4f16-a086-492ed9f88342</UserSecretsId>
+	  <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>

--- a/src/test/AspNetCore3.Sandbox/AspNetCore3.Sandbox.csproj
+++ b/src/test/AspNetCore3.Sandbox/AspNetCore3.Sandbox.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+	  <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/test/MvcTestApp/MvcTestApp.csproj
+++ b/src/test/MvcTestApp/MvcTestApp.csproj
@@ -5,6 +5,7 @@
     <SignAssembly>true</SignAssembly>
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>..\..\..\loupe.agent.snk</AssemblyOriginatorKeyFile>
+	  <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/test/MvcTestApp/Startup.cs
+++ b/src/test/MvcTestApp/Startup.cs
@@ -25,9 +25,8 @@ namespace MvcTestApp
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddLoupe()
-                .AddClientLogging();
-            services.AddControllersWithViews();
+            services.AddLoupe(builder => builder.AddClientLogging())
+                .AddControllersWithViews();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/test/MvcTestApp5/MvcTestApp5.csproj
+++ b/src/test/MvcTestApp5/MvcTestApp5.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <UserSecretsId>aspnet-MvcTestApp-1AA9A634-8BBC-42A2-A572-01D5700F6984</UserSecretsId>
+	  <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix #90 - Breaking change for our Services extensions to return IServiceCollection instead of the Agent Builder interface.  This matches then the behavior with a host builder as well.

Additionally, expose the EF Diagnostic Listener so it can be instanced directly to get around blocks in Azure Functions that prevent using our extension method.