### PR TITLE
Use AddHostedService with LoupeAgentService

### DIFF
--- a/src/Services/ServicesExtensions.cs
+++ b/src/Services/ServicesExtensions.cs
@@ -51,7 +51,7 @@ namespace Loupe.Agent.Core.Services
         public static IServiceCollection AddLoupe(this IServiceCollection services, Action<AgentConfiguration> configure = null)
         {
             AddOptions(services, configure);
-            services.AddSingleton<IHostedService, LoupeAgentService>();
+            services.AddHostedService<LoupeAgentService>();
             services.AddSingleton<LoupeAgent>();
 
             return services;
@@ -68,7 +68,7 @@ namespace Loupe.Agent.Core.Services
             Action<ILoupeAgentBuilder> agentBuilder, Action<AgentConfiguration> configure = null)
         {
             AddOptions(services, configure);
-            services.AddSingleton<IHostedService, LoupeAgentService>();
+            services.AddHostedService<LoupeAgentService>();
             services.AddSingleton<LoupeAgent>();
 
             if (agentBuilder != null)
@@ -92,7 +92,7 @@ namespace Loupe.Agent.Core.Services
             return builder.ConfigureServices((context, services) =>
             {
                 AddOptions(services, configure);
-                services.AddSingleton<IHostedService, LoupeAgentService>();
+                services.AddHostedService<LoupeAgentService>();
                 services.AddSingleton<LoupeAgent>();
             });
         }
@@ -109,7 +109,7 @@ namespace Loupe.Agent.Core.Services
             return builder.ConfigureServices((context, services) =>
             {
                 AddOptions(services, configure);
-                services.AddSingleton<IHostedService, LoupeAgentService>();
+                services.AddHostedService<LoupeAgentService>();
                 services.AddSingleton<LoupeAgent>();
 
                 agentBuilder(new LoupeAgentServicesCollectionBuilder(services));


### PR DESCRIPTION
`LoupeAgentService` was being added with `AddSingleton` instead of `AddHostedService`.

This change also uses the `LoupeAgentService` stop to call `Agent.End` to close the session gracefully.

This fixes an issue where the process doesn't terminate because the Agent is not closed.