### PR TITLE
Feature/ef disable log messages

### DIFF
--- a/src/EntityFramework/EntityFrameworkConfiguration.cs
+++ b/src/EntityFramework/EntityFrameworkConfiguration.cs
@@ -18,6 +18,7 @@ namespace Loupe.Agent.EntityFramework
         public EntityFrameworkConfiguration()
         {
             Enabled = true;
+            LogQuery = true;
             LogCallStack = false;
             QueryMessageSeverity = LogMessageSeverity.Verbose;
             LogExceptions = true;
@@ -36,6 +37,14 @@ namespace Loupe.Agent.EntityFramework
         /// </summary>
         /// <remarks>This is useful for determining what application code causes each query</remarks>
         public bool LogCallStack { get; set; }
+
+        /// <summary>
+        /// Determines if the agent writes a log message for each SQL operation.  Defaults to true.
+        /// </summary>
+        /// <remarks>Set to false to disable writing log messages for each SQL operation before they are run.
+        /// For database-heavy applications this can create a significant volume of log data, but does not
+        /// affect overall application performance.</remarks>
+        public bool LogQuery { get; set; }
 
         /// <summary>
         /// The severity used for log messages for the Entity Framework trace message. Defaults to Verbose.

--- a/src/EntityFramework/Internal/DatabaseMetric.cs
+++ b/src/EntityFramework/Internal/DatabaseMetric.cs
@@ -30,14 +30,14 @@ namespace Loupe.Agent.EntityFramework.Internal
         /// <summary>
         /// The shortened down version we used for recording the caption on the starting side.
         /// </summary>
-        public string ShortenedQuery { get; private set; }
+        public string? ShortenedQuery { get; private set; }
 
         /// <summary>
         /// The name of the stored procedure or query that was executed
         /// </summary>
         [EventMetricValue("queryName", SummaryFunction.Count, null, Caption = "Query Name",
             Description = "The name of the stored procedure or query that was executed")]
-        public string Query { get; private set; }
+        public string? Query { get; private set; }
 
 
         /// <summary>
@@ -45,21 +45,21 @@ namespace Loupe.Agent.EntityFramework.Internal
         /// </summary>
         [EventMetricValue("parameters", SummaryFunction.Count, null, Caption = "Parameters",
             Description = "The parameters that were provided as input to the query")]
-        public string Parameters { get; set; }
+        public string? Parameters { get; set; }
 
         /// <summary>
         /// The server the operation was run against
         /// </summary>
         [EventMetricValue("server", SummaryFunction.Count, null, Caption = "Server",
             Description = "The server the operation was run against")]
-        public string Server { get; set; }
+        public string? Server { get; set; }
 
         /// <summary>
         /// The database the operation was run against
         /// </summary>
         [EventMetricValue("database", SummaryFunction.Count, null, Caption = "Database",
             Description = "The database the operation was run against")]
-        public string Database { get; set; }
+        public string? Database { get; set; }
 
         /// <summary>
         /// The number of rows returned by the query
@@ -80,12 +80,12 @@ namespace Loupe.Agent.EntityFramework.Internal
         /// </summary>
         [EventMetricValue("result", SummaryFunction.Count, null, Caption = "Result",
             Description = "The result of the query; Success or an error message.")]
-        public string Result { get; set; }
+        public string? Result { get; set; }
 
         /// <summary>
         /// The message source provider for this call.
         /// </summary>
-        internal IMessageSourceProvider MessageSourceProvider { get; set; }
+        internal IMessageSourceProvider? MessageSourceProvider { get; set; }
 
         /// <summary>
         /// Stops the timer but doesn't record the metric yet.

--- a/src/EntityFramework/LoupeCommandInterceptor.cs
+++ b/src/EntityFramework/LoupeCommandInterceptor.cs
@@ -359,8 +359,7 @@ namespace Loupe.Agent.EntityFramework
             string paramString = null;
 
             //see if we have a tracking metric for this command...
-            DatabaseMetric trackingMetric;
-            _databaseMetrics.TryRemove(command.GetHashCode(), out trackingMetric);
+            _databaseMetrics.TryRemove(command.GetHashCode(), out var trackingMetric);
             if (trackingMetric != null)
             {
                 trackingMetric.Stop();
@@ -407,10 +406,7 @@ namespace Loupe.Agent.EntityFramework
                 }
             }
 
-            if (trackingMetric != null)
-            {
-                trackingMetric.Record();
-            }
+            trackingMetric?.Record();
         }
     }
 }

--- a/src/EntityFramework/LoupeCommandInterceptor.cs
+++ b/src/EntityFramework/LoupeCommandInterceptor.cs
@@ -70,6 +70,7 @@ namespace Loupe.Agent.EntityFramework
 
             LogCallStack = _configuration.LogCallStack;
             LogExceptions = _configuration.LogExceptions;
+            LogQuery = _configuration.LogQuery;
         }
 
         /// <summary>
@@ -95,6 +96,11 @@ namespace Loupe.Agent.EntityFramework
         /// Indicates if the call stack to the operation should be included in the log message
         /// </summary>
         public bool LogCallStack { get; set; }
+
+        /// <summary>
+        /// Indicates if a log message should be written for each database operation before it is performed.
+        /// </summary>
+        public bool LogQuery { get; set; }
 
         /// <summary>
         /// Indicates if execution exceptions should be logged
@@ -234,7 +240,7 @@ namespace Loupe.Agent.EntityFramework
 
             try
             {
-                var messageBuilder = new StringBuilder(1024);
+                var messageBuilder = LogQuery ? new StringBuilder(1024) : null;
 
                 string caption, shortenedQuery;
                 if (command.CommandType == CommandType.StoredProcedure)
@@ -245,7 +251,7 @@ namespace Loupe.Agent.EntityFramework
                 else
                 {
                     //we want to make a more compact version of the SQL Query for the caption...
-                    var queryLines = command.CommandText.Split(new[] {'\r', '\n'});
+                    var queryLines = command.CommandText.Split(new[] { '\r', '\n' });
 
                     //now rip out any leading/trailing white space...
                     var cleanedUpLines = new List<string>(queryLines.Length);
@@ -267,36 +273,39 @@ namespace Loupe.Agent.EntityFramework
                     if (shortenedQuery.Length > 512)
                     {
                         shortenedQuery = shortenedQuery.Substring(0, 512) + "(...)";
-                        messageBuilder.AppendFormat("Full Query:\r\n\r\n{0}\r\n\r\n", command.CommandText);
+                        messageBuilder?.AppendFormat("Full Query:\r\n\r\n{0}\r\n\r\n", command.CommandText);
                     }
+
                     caption = string.Format("Executing Sql: '{0}'", shortenedQuery);
                 }
 
-                string paramString = null;
+                string? paramString = null;
                 if (command.Parameters.Count > 0)
                 {
-                    messageBuilder.AppendLine("Parameters:");
+                    messageBuilder?.AppendLine("Parameters:");
  
                     var paramStringBuilder = new StringBuilder(1024);
                     foreach (DbParameter parameter in command.Parameters)
                     {
                         string value = parameter.Value.FormatDbValue();
-                        messageBuilder.AppendFormat("    {0}: {1}\r\n", parameter.ParameterName, value);
+                        messageBuilder?.AppendFormat("    {0}: {1}\r\n", parameter.ParameterName, value);
                         paramStringBuilder.AppendFormat("{0}: {1}, ", parameter.ParameterName, value);
                     }
 
                     paramString = paramStringBuilder.ToString();
                     paramString = paramString.Substring(0, paramString.Length - 2); //get rid of the trailing comma
 
-                    messageBuilder.AppendLine();
+                    messageBuilder?.AppendLine();
                 }
 
-                var trackingMetric = new DatabaseMetric(shortenedQuery, command.CommandText);
-                trackingMetric.Parameters = paramString;
+                var trackingMetric = new DatabaseMetric(shortenedQuery, command.CommandText)
+                {
+                    Parameters = paramString
+                };
 
                 if (command.Transaction != null)
                 {
-                    messageBuilder.AppendFormat("Transaction:\r\n    Id: {0:X}\r\n    Isolation Level: {1}\r\n\r\n", command.Transaction.GetHashCode(), command.Transaction.IsolationLevel);
+                    messageBuilder?.AppendFormat("Transaction:\r\n    Id: {0:X}\r\n    Isolation Level: {1}\r\n\r\n", command.Transaction.GetHashCode(), command.Transaction.IsolationLevel);
                 }
 
                 var connection = command.Connection;
@@ -304,18 +313,22 @@ namespace Loupe.Agent.EntityFramework
                 {
                     trackingMetric.Server = connection.DataSource;
                     trackingMetric.Database = connection.Database;
-                    messageBuilder.AppendFormat("Server:\r\n    DataSource: {3}\r\n    Database: {4}\r\n    Connection Timeout: {2:N0} Seconds\r\n    Provider: {0}\r\n    Server Version: {1}\r\n\r\n",
+                    messageBuilder?.AppendFormat("Server:\r\n    DataSource: {3}\r\n    Database: {4}\r\n    Connection Timeout: {2:N0} Seconds\r\n    Provider: {0}\r\n    Server Version: {1}\r\n\r\n",
                                                 connection.GetType(), connection.ServerVersion, connection.ConnectionTimeout, connection.DataSource, connection.Database);
                 }
 
                 var messageSourceProvider = new MessageSourceProvider(2); //It's a minimum of two frames to our caller.
-                if (LogCallStack)
+                if (LogQuery && messageBuilder != null)
                 {
-                    messageBuilder.AppendFormat("Call Stack:\r\n{0}\r\n\r\n", messageSourceProvider.StackTrace);
-                }
+                    if (LogCallStack)
+                    {
+                        messageBuilder.AppendFormat("Call Stack:\r\n{0}\r\n\r\n", messageSourceProvider.StackTrace);
+                    }
 
-                Log.Write(_configuration.QueryMessageSeverity, LogSystem, messageSourceProvider, null, null, LogWriteMode.Queued, null, LogCategory, caption,
-                          messageBuilder.ToString());
+                    Log.Write(_configuration.QueryMessageSeverity, LogSystem, messageSourceProvider, null, null,
+                        LogWriteMode.Queued, null, LogCategory, caption,
+                        messageBuilder.ToString());
+                }
 
                 trackingMetric.MessageSourceProvider = messageSourceProvider;
 


### PR DESCRIPTION
Address user request to disable normal logging of EF SQL actions since that can really crowd the log (and duplicates information put into the metrics area). The user wants to log failures, but not the start of each database operation.